### PR TITLE
New top-level Counties menu on Meetings map

### DIFF
--- a/publicmeetings.html
+++ b/publicmeetings.html
@@ -11,6 +11,7 @@
             <div class="heading">
                 <h1>Public Meetings in the Carolinas</h1>
             </div>
+            <div id="counties" class="listings"></div>
             <div id="listings" class="listings"></div>
         </div>
         <div id="map" class="map"></div>
@@ -175,15 +176,16 @@
         <script>
 
             mapboxgl.accessToken = 'pk.eyJ1IjoiY2N0aGVncmVhdCIsImEiOiJjbDI2a2lodnYwMnRnM2ZvdXVhZXNjbHd0In0.4CfhKr_VP1IDEM08Nk7PXg';
-
+            const stateCoords = [-79.8, 35.3] 
+            const defaultZoom = 6
             /**
              * Add the map to the page
              */
             const map = new mapboxgl.Map({
                 container: 'map',
                 style: 'mapbox://styles/mapbox/light-v10',
-                center: [-79.8, 35.3],
-                zoom: 5,
+                center: stateCoords,
+                zoom: defaultZoom,
                 scrollZoom: false
             });
 
@@ -417,18 +419,18 @@
                  * This is where your '.addLayer()' used to be, instead
                  * add only the source without styling a layer
                  */
-                map.addSource('places', {
-                    'type': 'geojson',
-                    'data': meetings
-                });
+                // map.addSource('places', {
+                //     'type': 'geojson',
+                //     'data': meetings
+                // });
 
                 /**
                  * Add all the things to the page:
                  * - The location listings on the side of the page
                  * - The markers onto the map
                  */
-                buildLocationList(meetings);
-                addMarkers(meetings);
+                // buildLocationList(meetings);
+                // addMarkers(meetings);
 
                 fetch("meetings.json")
                 .then(response => response.json())
@@ -437,8 +439,8 @@
                         'type': 'geojson',
                         'data': moreMeetings
                     });
-                    buildLocationList(moreMeetings);
-                    addMarkers(moreMeetings);
+
+                    buildCountyList(moreMeetings)
                 }).catch(function (err) {
                     console.log('Failed to load more meetings', err);
                 });
@@ -449,7 +451,7 @@
              **/
             function addMarkers(meetings) {
                 /* For each feature in the GeoJSON object above: */
-                for (const marker of meetings.features) {
+                for (const marker of meetings) {
                     /* Create a div element for the marker. */
                     const el = document.createElement('div');
                     /* Assign a unique `id` to the marker. */
@@ -473,7 +475,7 @@
                      **/
                     el.addEventListener('click', (e) => {
                         /* Fly to the point */
-                        flytoMeeting(marker);
+                        flytoMeeting(marker.geometry.coordinates, 15);
                         /* Close all other popups and display popup for clicked meeting */
                         createPopUp(marker);
                         /* Highlight listing in sidebar */
@@ -491,10 +493,123 @@
             }
 
             /**
+             * Clear the map of markers and zoom back out
+             * Remove popup
+             */
+             function removeAllMarkers() {
+                const markers = document.querySelectorAll('.marker')
+                const popup = document.querySelector('.mapboxgl-popup')
+                if(popup) popup.remove()
+                for(const marker of markers) {
+                    marker.remove()
+                }
+                flytoMeeting();
+             }
+
+            /** 
+             * Builds and returns a full meeting list separated by county
+            **/
+            function buildMeetingListByCounty(meetingList) {
+                return meetingList.features.reduce((obj, item) => {
+                    const county = item.properties.government;
+
+                    if (county !== "") {
+                        if (!obj[county]) {
+                            obj[county] = [{properties: {...item.properties}, geometry: {...item.geometry}}];
+                        } else {
+                            obj[county].push({properties: {...item.properties}, geometry: {...item.geometry}});
+                        }
+                    }
+                    return obj;
+                }, []);
+            }
+
+            /** 
+             * Adds the County list to sidebar
+            **/
+            function buildCountyList(meetingList) {
+                const countyList = buildMeetingListByCounty(meetingList)
+                const counties = document.querySelector('#counties');
+                /* Sort list of counties */
+                const sortedCounties = Object.keys(countyList).sort((c1, c2) => c1.localeCompare(c2))
+
+                for (const countyName of sortedCounties) {
+
+                    /* Add a new county listing section to the sidebar. */
+                    const county = counties.appendChild(document.createElement('div'));
+                    /* Assign the `item` class to each listing for styling. */
+                    county.className = 'item';
+
+                    /* Add the link to the individual listing created above. */
+                    const link = county.appendChild(document.createElement('a'));
+                    link.href = '#';
+                    link.className = 'title';
+                    link.id = `${countyName}`;
+                    link.innerHTML = `${countyName}`
+
+                }
+                /** 
+                 * Uses event delegation to listen for clicks on list items 
+                 * Build meeting list for the county and add markers to map
+                 **/
+
+                counties.addEventListener('click', function(event) {
+                    // ignore if not clicking on link
+                    if(!event.target.matches('.title')) return
+                    event.preventDefault();
+                    
+                    // hide counties list when a county is clicked
+                    counties.style.display = 'none'
+
+                    const meetingList = countyList[event.target.id]
+                    
+                    /* Fly to general are of listings*/
+                    flytoMeeting(meetingList[0].geometry.coordinates, 8)
+                    buildLocationList(meetingList)
+                    addMarkers(meetingList)
+                }, false)
+                return countyList
+            }
+
+            /**
+             *  Back button handles re-showing the county list
+             *  Removes previous meeting listings and each event handler
+             *  Removes markers from maps
+             *  String with selector type is required for now
+             *  Future: pass the elements as arguments
+             **/
+            function backButton(showElem, parentElem, removeEle) {
+                const listings = document.querySelector(parentElem)
+                const backButton = listings.appendChild(document.createElement('div'))
+                backButton.className = 'item'
+                
+                /* Make the back button a link for accessibility */
+                const link = backButton.appendChild(document.createElement('a'))
+                link.href = '#'
+                link.className = 'title'
+                link.id = 'Back'
+                link.innerText = '< Back to Counties'
+
+                
+                backButton.addEventListener('click', () => {
+                    document.querySelector(showElem).style.display = 'block'
+                    removeAllMarkers();
+                    const collection = listings.querySelectorAll(removeEle)
+                    for (const elem of collection) {
+                        elem.parentNode.removeChild(elem)
+                    }
+                })
+            }
+
+            /**
              * Add a listing for each meeting to the sidebar.
              **/
             function buildLocationList(meetings) {
-                for (const meeting of meetings.features) {
+                /* Add back button to top of list to nav back to counties */
+                backButton('#counties', '#listings', '.item')
+
+                /* Continue to add meeting listings */
+                for (const meeting of (meetings)) {
                     /* Add a new listing section to the sidebar. */
                     const listings = document.getElementById('listings');
                     const listing = listings.appendChild(document.createElement('div'));
@@ -525,9 +640,9 @@
                      * 4. Highlight listing in sidebar (and remove highlight for all other listings)
                      **/
                     link.addEventListener('click', function () {
-                        for (const feature of meetings.features) {
+                        for (const feature of meetings) {
                             if (this.id === `link-${feature.properties.id}`) {
-                                flytoMeeting(feature);
+                                flytoMeeting(feature.geometry.coordinates, 15);
                                 createPopUp(feature);
                             }
                         }
@@ -538,16 +653,18 @@
                         this.parentNode.classList.add('active');
                     });
                 }
+                
             }
 
             /**
              * Use Mapbox GL JS's `flyTo` to move the camera smoothly
              * a given center point.
+             * Defaults: coords = center of State, zoomLevel = state in focus
              **/
-            function flytoMeeting(currentFeature) {
+            function flytoMeeting(coords = stateCoords, zoomLevel = defaultZoom) {
                 map.flyTo({
-                    center: currentFeature.geometry.coordinates,
-                    zoom: 15
+                    center: coords,
+                    zoom: zoomLevel
                 });
             }
 


### PR DESCRIPTION
- Created a top-level  menu on the map for the counties represented in the meetings.json file
  - Created the county list using the government property on each meetings  
  - Ignoring meetings with a blank string in the government property
  - Sorted the Counties Alphabetically. 
- Changed the flytomeeting function to be more reusable
- Added default zoom level and coordinates for map
- Added back button to meeting list, to navigate back to Counties menu