### PR TITLE
Meetings at same location and pulling meetings from csv on google docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,24 +420,33 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 	    </p>
 	    
       <h2>Meeting Evaluation</h2>
-      <p>Our meeting evaluation tools will be based on the following findings by
-        Code for Asheville, <a href="https://adhoc.team/playbook-accessibility/" target="_blank">Accessibility Beyond
-          Compliance</a>, as well as additional sources on usability: </p>
-      <p>During the creation of this policy proposal, the following challenges with public
-        participation were identified:</p>
+      <p>Our meeting evaluation tools are based on Code for Asheville's summary of their observations, <a href="https://www.plainlanguage.gov/resources/checklists/web-checklist/" target="_blank">resources on plain language from the U.S. government</a>, 
+	      <a href="https://adhoc.team/playbook-accessibility/" target="_blank">Accessibility Beyond Compliance</a>, and other sources on usability. </p>
+      
+	   <details>
+        <summary>
+          <h3>Code for Asheville's findings</h3>
+        </summary> 
+	    <p>During Code for Asheville's observations of public meetings, they identified the following challenges with public
+        participation and described them in their proposed  <a href="https://docs.google.com/document/d/e/2PACX-1vQDj9Ey7xh52bENqU2oYct6AQxLd8hJv-bY0B_9ZvCajC4cfFCdnQ_2_4QRHWxeEFgf7LkuHkMfg6Ed/pub" target="_blank">Open Meetings Policy</a>:</p>
       <ul>
-        <li>The current public comment process requires a burdensome advance sign-up
-          process that requires disclosure of unnecessary personal information.</li>
-        <li>Meeting materials do not contain a clear indication of updates or modifications
-          to documents that were posted previously.</li>
-        <li>Local government entities lack data-driven metrics of public participation, such as
+	<li>The ever-changing processes for public comment makes it unclear how the public can participate in public comment, and difficult to know what to expect from the process.</li>
+	<li>Public comment and other opportunities for feedback are not provided at every meeting - there should be consistent, ongoing opportunities for public input.</li>
+	<li>Public comment is not allowed for all agenda items, and the criteria under which comment is allowed varies between public bodies. </li> 
+	<li>The current public comment process requires a burdensome advance sign-up process that requires disclosure of unnecessary personal information.</li>
+	<li>Due to technical or process issues, residents have been disconnected or skipped during public comment periods. We lack a fair process to ensure these residents are provided an opportunity to participate.</li>
+	<li>Meeting materials are not posted online in advance of meetings on a clear, consistent schedule. Meeting minutes are not consistently posted in a timely manner after meetings.</li>
+	<li>Meeting materials do not contain a clear indication of updates or modifications to documents that were posted previously.</li>
+	<li>Local government entities publish meeting information on a variety of platforms and websites, making it difficult to know which source of information is the official (and most up-to-date) source of information. This creates additional work for staff and board members as any updates need to be posted in multiple locations.</li>
+	<li>Basic board information, such as membership, contact information, meeting schedules, and bylaws are not posted or updated consistently for all public bodies.</li>
+	 <li>Local government entities lack data-driven metrics of public participation, such as
           the number of comments or the methods under which they were provided. As a result, it is
           challenging for staff, elected officials, or the public to analyze how changes to the public
           meeting process increase or decrease public participation.</li>
         <li>Due to a lack of consistency in the process for public participation, it can be
           difficult to evaluate public support or opposition to measures considered by public bodies.</li>
       </ul>
-
+      </details>
       <!-- Before the meeting -->
       <details>
         <summary>

--- a/index.html
+++ b/index.html
@@ -42,12 +42,26 @@
   <main>
  <!--Introduction & Map Section-->
     <section id="introduction-section">
-      <h2><span>Welcome!</span> This Toolkit is for community-based teams, such as Code for America
-        Brigades, who want to evaluate and improve the openness of local public meetings in North Carolina. </h2>
+      <h2><span>Welcome!</span> The Open Meeting Toolkit helps community-based teams, such as Code for America
+        Brigades, to evaluate and improve the openness of local public meetings while engaging civic technology volunteers. </h2>
       <br>
-      <iframe src="publicmeetings.html" width="90%" height="550px" title="Map Container"
+           <h2>Introduction</h2>
+      <p>
+      The Open Meeting Toolkit for the Carolinas builds on the Open Meetings Policy project by Sunshine Request and Code for Asheville. Volunteers in Asheville 
+        attended local government meetings, observed barriers to participation, synthesized their findings, developed a policy proposal, gathered support, and 
+        presented that proposal to their local government. Code for the Carolinas volunteers realized the potential in their project to improve access to local
+        government statewide and to engage civic technology volunteers with a variety of skills and backgrounds. Code for America recognized this scaling project 
+        as a Summer 2022 Impact Sprint. 
+        
+        This website provides resources to support a team of volunteers using the Toolkit to improve access to public meetings in their North Carolina community. 
+        Resources include instructions for mapping public meetings, doing an environmental scan of local community features that affect public meetings, forms for taking 
+        structured notes about public meetings (before, during, and after), guidance on synthesizing observations, and examples of recommendations.        
+  <figure>
+       <iframe src="publicmeetings.html" width="90%" height="550px" title="Map of Public Meetings in the Carolinas"
         style="border: 1px solid #222;"></iframe>
-    </section>
+  <figcaption>Map of public meetings in the Carolinas.</figcaption>
+</figure>
+   </section>
 <!--Local Scan & Toolkit Insruction Section-->
     <section id="scan-section">
       <h2>Local Scan</h2>

--- a/index.html
+++ b/index.html
@@ -730,7 +730,7 @@
 <li>Sign language interpreter</li>
 <li>Verbal description or explanation of images such as charts
 </ul></li>
-<li>Was the online meeting disrupted by technical problems? Mark all that apply.
+<li>Was the meeting disrupted by technical problems? Mark all that apply.
 <ul>
 <li>No, at most minor technical difficulties that were quickly resolved.</li>
 <li>Yes, the public body holding the meeting had technical problems.</li>

--- a/index.html
+++ b/index.html
@@ -83,19 +83,19 @@
         <p>
 The Public Meetings in North Carolina map is a tool to visualize and learn about public meetings in North Carolina. 
 
-	<ul>Adding meetings to the map is a jump-right-in activity that lets any new volunteer contribute to the Open Meeting Toolkit project.	</ul>
-	<ul>The map can be a compelling visual for outreach to engage new participants.	</ul>
-	<ul>The map can be useful to local teams planning to evaluate meetings.	</ul>
-	<ul>We can support local teams by helping to complete maps for their communities.	</ul>
-	<ul>We could find a partner who commits to host and maintain the map (not very likely)	</ul>
-	<ul>Local teams could find partners who commit to hosting and maintaining maps for their county (more likely).	</ul>
-	<ul>Code for the Carolinas has not committed to completing or maintaining the map.	</ul>
+	<ul><li>Adding meetings to the map is a jump-right-in activity that lets any new volunteer contribute to the Open Meeting Toolkit project.</li>
+	<li>The map can be a compelling visual for outreach to engage new participants.	</li>
+	<li>The map can be useful to local teams planning to evaluate meetings.	</li>
+	<li>We can support local teams by helping to complete maps for their communities.</li>
+	<li>We could find a partner who commits to host and maintain the map (not very likely).</li>
+	<li>Local teams could find partners who commit to hosting and maintaining maps for their county (more likely).	</li>
+	<li>Code for the Carolinas has not committed to completing or maintaining the map.</li></ul>
 
 To add meetings to the map, provide a comma-separated value (.csv) file containing the fields from the Data Dictionary to the Code for the Carolinas team. 
 Include as many fields as possible for the meetings in your community, keeping in mind that some information may not be available online. You can collect this 
 data in any spreadsheet program. Once you have collected the data, export it in .csv format and save it as meetings.csv. Provide it to Code for the Carolinas. 
 </p>
-
+	    <h4>Data Dictionary</h4>
 <table>
   <tr>
     <th>Field</th>
@@ -121,10 +121,17 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 <td>	Text	</td>
 <td>	City Hall	</td>
 </tr>
-</table>
+<tr>	<td>	Address	</td><td>	Postal address of the meeting location		</td><td>	Text	</td><td>	123 Address Street, City, ST 54321	</td>	</tr>
+<tr>	<td>	Latitude	</td><td>	Distance north or south of the equator		</td><td>	Numeric	</td><td>		</td>	</tr>
+<tr>	<td>	Longitude	</td><td>	Distance east or west of the zero meridian		</td><td>	Numeric	</td><td>		</td>	</tr>
+<tr>	<td>	Schedule	</td><td>	Days on which the meeting is regularly held		</td><td>	Text	</td><td>	2nd Tuesday of the month	</td>	</tr>
+<tr>	<td>	Start time	</td><td>	Time at which the meeting starts		</td><td>	Time	</td><td>	0.541666667	</td>	</tr>
+<tr>	<td>	End time	</td><td>	Time at which the meeting ends		</td><td>	Time	</td><td>	0.625	</td>	</tr>
+<tr>	<td>	Remote options	</td><td>	Description of options to attend the meeting online		</td><td>	Text	</td><td>	Zoom	</td>	</tr>
+<tr>	<td>	Source	</td><td>	Webpage of the government and public body holding the meeting		</td><td>	Hyperlink	</td><td>	https://www.buncombecounty.org/transparency/boards-commissions/default.aspx	</td>	</tr>
+</table>	
 
       </details>
-      -->
       
       <!--STEEPLE Analysis Section  -->
       <details>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,6 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 	    <h4>Data Dictionary</h4>
 <table> {
   border-spacing: 10px;
-}
   <tr>
     <th>Field</th>
     <th>Definition</th>
@@ -114,7 +113,7 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 <tr>	<td>	End time	</td><td>	Time at which the meeting ends					</td><td>	Time	</td><td>	0.625	</td>	</tr>
 <tr>	<td>	Remote options	</td><td>	Description of options to attend the meeting online		</td><td>	Text	</td><td>	Zoom	</td>	</tr>
 <tr>	<td>	Source		</td><td>	Webpage of the government and public body holding the meeting	</td><td>	URL	</td><td>	https://www.buncombecounty.org/transparency/boards-commissions/default.aspx	</td>	</tr>
-</table>	
+}</table>	
 
       </details>
       
@@ -607,6 +606,26 @@ data in any spreadsheet program. Once you have collected the data, export it in 
     </section>
     <section id="faq-section">
       <h2>Frequently Asked Questions</h2>
+	    
+	<h3>What is a public meeting?</h3>
+	<p>We use the term public meeting to refer to local government meetings that are required by law (NC General Statute Chapter 143 33C) to allow the public to 
+	attend and, in some cases, to provide public comment. From the statute: "public body" means any elected or appointed authority, board, commission, committee, council,
+	or other body of the State, or of one or more counties, cities, school administrative units, constituent institutions of The University of North Carolina, or other political
+	subdivisions or public corporations in the State that (i) is composed of two or more members and (ii) exercises or is authorized to exercise a legislative, policy-making, 
+	quasi-judicial, administrative, or advisory function." There are a few additional considerations, so if you are in doubt, please consult the statute.</p>  	
+	<h3>Can I use the Open Meeting Toolkit for the Carolinas in other places besides North Carolina?</h3>
+	<p>There is some interest in adapting the Toolkit for use in other places. Right now, it provides resources for North Carolina.</p>	    
+	<h3>Does my local team need to have a leader?</h3>
+	<p>No, the Toolkit can be used by self-directed teams who share responsibility.</p>
+	<h3>What if I notice a technical problem or want to suggest an improvement?<h3>
+	<p>The Toolkit is being developed by civic technology volunteers. If you are a civic technology volunteer yourself and know how to fix the problem, we	
+	invite you to  <a href="https://github.com/Code-for-the-Carolinas/openmeetingtoolkit" target="_blank">collaborate with us on GitHub</a>. You are also welcome
+	to contact Code for the Carolinas by email: info at codeforthecarolinas dot org.</p>
+	<h3>Is the Toolkit suitable for research?<h3>	
+	<p>No, the Toolkit provides a structure and resources for local teams to make observations to help inform improvements to public meetings in 
+	their own communities. Findings from the Toolkit are not intended for publication or as contributions to general knowledge. Use of the Toolkit may
+	involve recording some public information about public officials, but in general it is for recording information about public meetings, not people.</p>
+	
     </section>
     <section id="contact-section">
       <h2>Contact</h2>

--- a/index.html
+++ b/index.html
@@ -199,7 +199,10 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 	      </li>
             <li>Complete and submit the pages of the STEEPLE Analysis form in order. While you can't go backward on the form, you can change your responses directly in the STEEPLE Analysis table in Baserow. You can also use the link to generate a new, blank form and complete only the pages you want to change.</li>
           </ol>
-	  
+	  <p>
+	The STEEPLE analysis and meeting evaluation questions are listed below so that you can easily review them while you prepare or refer to them while you complete the Baserow forms. There are also links to 
+		  references that will help you answer some of the questions.
+	  </p>
 	  	 <p><strong>Temporary Instructions</strong></p>
 	 <br>
 	 <p><strong>At this time Baserow creates a new row for each part of the STEEPLE form. If you prefer, you can copy and paste organize all data into same row.</strong>
@@ -405,6 +408,17 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 
     <!--Meeting Evaluation Section-->
     <section id="evaluation-section">
+	<h2>Meeting Marathon Plan</h2>
+    <p>
+	    When your team has completed the local scan, it's time to plan which meetings you will attend. Look over meeting data for your community on the map of public meetings, 
+	    on the meetings data file your team prepared, or on the website of your local government. 
+	    </p><p>
+	    For fun, use this <a href="https://docs.google.com/document/d/1rzDyY1SPl5N68InYZ6To4OyWwdS5qRcGnJvGjq3oouE/edit?usp=sharing" target="_blank">Meeting Marathon template</a>  to organize your team's plan around the theme of a Meeting Marathon. Because some of the most common races are 5K, 10K and marathons (26.2 miles)
+	    challenge your team to pledge to attend 5, 10, or 26 meetings! Make a copy of the Google Document, complete the table with the date, public body, 
+	    and team member for each meeting. Don't forget to allow a week before the meeting and a week after the meeting to check information for the Before Meeting
+	    and After Meeting evaluation forms. Keep the template for your records so you can follow up with teammates and encourage them. 
+	    </p>
+	    
       <h2>Meeting Evaluation</h2>
       <p>Our meeting evaluation tools will be based on the following findings by
         Code for Asheville, <a href="https://adhoc.team/playbook-accessibility/" target="_blank">Accessibility Beyond

--- a/index.html
+++ b/index.html
@@ -115,6 +115,12 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 <td>	Binary	</td>
 <td>	1	</td>
   </tr>
+<tr>
+<td>	Location	</td>
+<td>	Public place or building for which the meeting is held		</td>
+<td>	Text	</td>
+<td>	City Hall	</td>
+</tr>
 </table>
 
       </details>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,11 @@
       <h2><span>Welcome!</span> The Open Meeting Toolkit helps community-based teams, such as Code for America
         Brigades, to evaluate and improve the openness of local public meetings while engaging civic technology volunteers. </h2>
       <br>
+  <figure>
+       <iframe src="publicmeetings.html" width="90%" height="550px" title="Map of Public Meetings in the Carolinas"
+        style="border: 1px solid #222;"></iframe>
+  <figcaption>Map of public meetings in the Carolinas.</figcaption>
+</figure>
            <h2>Introduction</h2>
       <p>
       The Open Meeting Toolkit for the Carolinas builds on the Open Meetings Policy project by Sunshine Request and Code for Asheville. Volunteers in Asheville 
@@ -55,16 +60,19 @@
         
         This website provides resources to support a team of volunteers using the Toolkit to improve access to public meetings in their North Carolina community. 
         Resources include instructions for mapping public meetings, doing an environmental scan of local community features that affect public meetings, forms for taking 
-        structured notes about public meetings (before, during, and after), guidance on synthesizing observations, and examples of recommendations.        
-  <figure>
-       <iframe src="publicmeetings.html" width="90%" height="550px" title="Map of Public Meetings in the Carolinas"
-        style="border: 1px solid #222;"></iframe>
-  <figcaption>Map of public meetings in the Carolinas.</figcaption>
-</figure>
+        structured notes about public meetings (before, during, and after), guidance on synthesizing observations, and examples of recommendations.
+      </p> 
    </section>
-<!--Local Scan & Toolkit Insruction Section-->
+<!--Local Scan & Toolkit Instruction Section-->
     <section id="scan-section">
       <h2>Local Scan</h2>
+      
+      <p>
+        Start by getting to know some background about public meetings in your community. The Toolkit's local scan includes two activities to help you prepare: 
+        a map of public meetings and an environmental scan, called a STEEPLE analysis.
+      </p>
+      
+      
       <h3>Instructions for this Toolkit</h3>
 
       <!--Map Instructions-->
@@ -72,7 +80,43 @@
         <summary>
           <h3>Add Meetings to the Map</h3>
         </summary>
-        <p>Instructions to adding a meeting to the map to be added here</p>
+        <p>
+The Public Meetings in North Carolina map is a tool to visualize and learn about public meetings in North Carolina. 
+
+	<ul>Adding meetings to the map is a jump-right-in activity that lets any new volunteer contribute to the Open Meeting Toolkit project.	</ul>
+	<ul>The map can be a compelling visual for outreach to engage new participants.	</ul>
+	<ul>The map can be useful to local teams planning to evaluate meetings.	</ul>
+	<ul>We can support local teams by helping to complete maps for their communities.	</ul>
+	<ul>We could find a partner who commits to host and maintain the map (not very likely)	</ul>
+	<ul>Local teams could find partners who commit to hosting and maintaining maps for their county (more likely).	</ul>
+	<ul>Code for the Carolinas has not committed to completing or maintaining the map.	</ul>
+
+To add meetings to the map, provide a comma-separated value (.csv) file containing the fields from the Data Dictionary to the Code for the Carolinas team. 
+Include as many fields as possible for the meetings in your community, keeping in mind that some information may not be available online. You can collect this 
+data in any spreadsheet program. Once you have collected the data, export it in .csv format and save it as meetings.csv. Provide it to Code for the Carolinas. 
+</p>
+
+<table>
+  <tr>
+    <th>Field</th>
+    <th>Definition</th>
+    <th>Format</th>
+    <th>Example</th>
+  </tr>
+  <tr>
+<td>	Public body	</td>
+<td>	Part of the local government that holds the meeting, such as a board or commission		</td>
+<td>	Text	</td>
+<td>	Asheville Planning Board	</td>
+  </tr>
+  <tr>
+<td>	On map	</td>
+<td>	1 means the meeting is listed on the map, blank means it is not listed		</td>
+<td>	Binary	</td>
+<td>	1	</td>
+  </tr>
+</table>
+
       </details>
       -->
       

--- a/index.html
+++ b/index.html
@@ -94,8 +94,7 @@ Include as many fields as possible for the meetings in your community, keeping i
 data in any spreadsheet program. Once you have collected the data, export it in .csv format and save it as meetings.csv. Provide it to Code for the Carolinas. 
 </p>
 	    <h4>Data Dictionary</h4>
-<table> {
-  border-spacing: 10px;
+<table> 
   <tr>
     <th>Field</th>
     <th>Definition</th>
@@ -113,7 +112,7 @@ data in any spreadsheet program. Once you have collected the data, export it in 
 <tr>	<td>	End time	</td><td>	Time at which the meeting ends					</td><td>	Time	</td><td>	0.625	</td>	</tr>
 <tr>	<td>	Remote options	</td><td>	Description of options to attend the meeting online		</td><td>	Text	</td><td>	Zoom	</td>	</tr>
 <tr>	<td>	Source		</td><td>	Webpage of the government and public body holding the meeting	</td><td>	URL	</td><td>	https://www.buncombecounty.org/transparency/boards-commissions/default.aspx	</td>	</tr>
-}</table>	
+</table>	
 
       </details>
       
@@ -123,7 +122,8 @@ data in any spreadsheet program. Once you have collected the data, export it in 
           <h3>Complete a STEEPLE Analysis</h3>
         </summary>
         <p>
-		The STEEPLE Analysis helps you get to know about your community in ways that will help you identify barriers to participating in public meetings. 
+		The STEEPLE Analysis helps you get to know about your community in ways that will help you identify barriers to participating in public meetings. When the project 
+		team shared this part of the Toolkit with Sunshine Request and Code for Asheville, they said this type of up-front analysis would have made their work a lot easier!
 	      
 	      <p>
           The STEEPLE Analysis comes from a tool called the PEST analysis.
@@ -424,7 +424,7 @@ data in any spreadsheet program. Once you have collected the data, export it in 
       
 	   <details>
         <summary>
-          <h3>Code for Asheville's findings</h3>
+          <h4>Code for Asheville's findings</h4>
         </summary> 
 	    <p>During Code for Asheville's observations of public meetings, they identified the following challenges with public
         participation and described them in their proposed  <a href="https://docs.google.com/document/d/e/2PACX-1vQDj9Ey7xh52bENqU2oYct6AQxLd8hJv-bY0B_9ZvCajC4cfFCdnQ_2_4QRHWxeEFgf7LkuHkMfg6Ed/pub" target="_blank">Open Meetings Policy</a>:</p>
@@ -608,20 +608,25 @@ data in any spreadsheet program. Once you have collected the data, export it in 
       <h2>Frequently Asked Questions</h2>
 	    
 	<h3>What is a public meeting?</h3>
-	<p>We use the term public meeting to refer to local government meetings that are required by law (NC General Statute Chapter 143 33C) to allow the public to 
+	<p>We use the term public meeting to refer to local government meetings that are required by law (<a href="https://www.ncleg.net/EnactedLegislation/Statutes/PDF/ByArticle/Chapter_143/Article_33C.pdf"
+              target="_blank">"NC General Statute Chapter 143 33C"</a>) to allow the public to 
 	attend and, in some cases, to provide public comment. From the statute: "public body" means any elected or appointed authority, board, commission, committee, council,
 	or other body of the State, or of one or more counties, cities, school administrative units, constituent institutions of The University of North Carolina, or other political
 	subdivisions or public corporations in the State that (i) is composed of two or more members and (ii) exercises or is authorized to exercise a legislative, policy-making, 
 	quasi-judicial, administrative, or advisory function." There are a few additional considerations, so if you are in doubt, please consult the statute.</p>  	
+	<br>
 	<h3>Can I use the Open Meeting Toolkit for the Carolinas in other places besides North Carolina?</h3>
 	<p>There is some interest in adapting the Toolkit for use in other places. Right now, it provides resources for North Carolina.</p>	    
+	<br>
 	<h3>Does my local team need to have a leader?</h3>
 	<p>No, the Toolkit can be used by self-directed teams who share responsibility.</p>
-	<h3>What if I notice a technical problem or want to suggest an improvement?<h3>
+	<br>
+	<h3>What if I notice a technical problem or want to suggest an improvement?</h3>
 	<p>The Toolkit is being developed by civic technology volunteers. If you are a civic technology volunteer yourself and know how to fix the problem, we	
 	invite you to  <a href="https://github.com/Code-for-the-Carolinas/openmeetingtoolkit" target="_blank">collaborate with us on GitHub</a>. You are also welcome
 	to contact Code for the Carolinas by email: info at codeforthecarolinas dot org.</p>
-	<h3>Is the Toolkit suitable for research?<h3>	
+	<br>
+	<h3>Is the Toolkit suitable for research?</h3>	
 	<p>No, the Toolkit provides a structure and resources for local teams to make observations to help inform improvements to public meetings in 
 	their own communities. Findings from the Toolkit are not intended for publication or as contributions to general knowledge. Use of the Toolkit may
 	involve recording some public information about public officials, but in general it is for recording information about public meetings, not people.</p>

--- a/index.html
+++ b/index.html
@@ -71,9 +71,6 @@
         Start by getting to know some background about public meetings in your community. The Toolkit's local scan includes two activities to help you prepare: 
         a map of public meetings and an environmental scan, called a STEEPLE analysis.
       </p>
-      
-      
-      <h3>Instructions for this Toolkit</h3>
 
       <!--Map Instructions-->
       <details>
@@ -81,7 +78,8 @@
           <h3>Add Meetings to the Map</h3>
         </summary>
         <p>
-The Public Meetings in North Carolina map is a tool to visualize and learn about public meetings in North Carolina. 
+The Public Meetings in North Carolina map is a tool to visualize and learn about public meetings in North Carolina.
+	</p>
 
 	<ul><li>Adding meetings to the map is a jump-right-in activity that lets any new volunteer contribute to the Open Meeting Toolkit project.</li>
 	<li>The map can be a compelling visual for outreach to engage new participants.	</li>
@@ -90,45 +88,32 @@ The Public Meetings in North Carolina map is a tool to visualize and learn about
 	<li>We could find a partner who commits to host and maintain the map (not very likely).</li>
 	<li>Local teams could find partners who commit to hosting and maintaining maps for their county (more likely).	</li>
 	<li>Code for the Carolinas has not committed to completing or maintaining the map.</li></ul>
-
+<p>
 To add meetings to the map, provide a comma-separated value (.csv) file containing the fields from the Data Dictionary to the Code for the Carolinas team. 
 Include as many fields as possible for the meetings in your community, keeping in mind that some information may not be available online. You can collect this 
 data in any spreadsheet program. Once you have collected the data, export it in .csv format and save it as meetings.csv. Provide it to Code for the Carolinas. 
 </p>
 	    <h4>Data Dictionary</h4>
-<table>
+<table> {
+  border-spacing: 10px;
+}
   <tr>
     <th>Field</th>
     <th>Definition</th>
     <th>Format</th>
     <th>Example</th>
   </tr>
-  <tr>
-<td>	Public body	</td>
-<td>	Part of the local government that holds the meeting, such as a board or commission		</td>
-<td>	Text	</td>
-<td>	Asheville Planning Board	</td>
-  </tr>
-  <tr>
-<td>	On map	</td>
-<td>	1 means the meeting is listed on the map, blank means it is not listed		</td>
-<td>	Binary	</td>
-<td>	1	</td>
-  </tr>
-<tr>
-<td>	Location	</td>
-<td>	Public place or building for which the meeting is held		</td>
-<td>	Text	</td>
-<td>	City Hall	</td>
-</tr>
-<tr>	<td>	Address	</td><td>	Postal address of the meeting location		</td><td>	Text	</td><td>	123 Address Street, City, ST 54321	</td>	</tr>
-<tr>	<td>	Latitude	</td><td>	Distance north or south of the equator		</td><td>	Numeric	</td><td>		</td>	</tr>
-<tr>	<td>	Longitude	</td><td>	Distance east or west of the zero meridian		</td><td>	Numeric	</td><td>		</td>	</tr>
-<tr>	<td>	Schedule	</td><td>	Days on which the meeting is regularly held		</td><td>	Text	</td><td>	2nd Tuesday of the month	</td>	</tr>
-<tr>	<td>	Start time	</td><td>	Time at which the meeting starts		</td><td>	Time	</td><td>	0.541666667	</td>	</tr>
-<tr>	<td>	End time	</td><td>	Time at which the meeting ends		</td><td>	Time	</td><td>	0.625	</td>	</tr>
+<tr><td>	Public body	</td><td>	Local government board or commission holding the meeting	</td><td>	Text	</td><td>	Asheville Planning Board	</td>  </tr>
+<tr><td>	On map		</td><td>	1 means the meeting is listed on the map, blank = not listed	</td><td>	Binary	</td> <td>	1	</td>  </tr>
+<tr>	<td>	Location	</td> <td>	Public place or building for which the meeting is held		</td><td>	Text	</td><td>	City Hall	</td></tr>
+<tr>	<td>	Address		</td><td>	Postal address of the meeting location				</td><td>	Text	</td><td>	123 Address Street, City, ST 54321	</td>	</tr>
+<tr>	<td>	Latitude	</td><td>	Distance north or south of the equator				</td><td>	Numeric	</td><td>	35.05118986		</td>	</tr>
+<tr>	<td>	Longitude	</td><td>	Distance east or west of the zero meridian			</td><td>	Numeric	</td><td>	-78.87702582	</td>	</tr>
+<tr>	<td>	Schedule	</td><td>	Days on which the meeting is regularly held			</td><td>	Text	</td><td>	2nd Tuesday of the month	</td>	</tr>
+<tr>	<td>	Start time	</td><td>	Time at which the meeting starts				</td><td>	Time	</td><td>	0.541666667	</td>	</tr>
+<tr>	<td>	End time	</td><td>	Time at which the meeting ends					</td><td>	Time	</td><td>	0.625	</td>	</tr>
 <tr>	<td>	Remote options	</td><td>	Description of options to attend the meeting online		</td><td>	Text	</td><td>	Zoom	</td>	</tr>
-<tr>	<td>	Source	</td><td>	Webpage of the government and public body holding the meeting		</td><td>	Hyperlink	</td><td>	https://www.buncombecounty.org/transparency/boards-commissions/default.aspx	</td>	</tr>
+<tr>	<td>	Source		</td><td>	Webpage of the government and public body holding the meeting	</td><td>	URL	</td><td>	https://www.buncombecounty.org/transparency/boards-commissions/default.aspx	</td>	</tr>
 </table>	
 
       </details>
@@ -139,6 +124,9 @@ data in any spreadsheet program. Once you have collected the data, export it in 
           <h3>Complete a STEEPLE Analysis</h3>
         </summary>
         <p>
+		The STEEPLE Analysis helps you get to know about your community in ways that will help you identify barriers to participating in public meetings. 
+	      
+	      <p>
           The STEEPLE Analysis comes from a tool called the PEST analysis.
           It was developed by Harvard Business Professor Francis J. Aguilar,
           in his 1964 book Scanning the Business Environment. The main idea behind this process is
@@ -150,41 +138,42 @@ data in any spreadsheet program. Once you have collected the data, export it in 
           (example: political next to legal).
         </p>
 
-        <!-- Instuctions -->
+        <!-- Instructions -->
         <details>
           <summary><span>STEEPLE Analysis Instructions:</span></summary>
           <p>Plan to bring your team together for about one hour to complete the STEEPLE Analysis. You will do this
             analysis to help your own local team prepare to evaluate local government meetings.
+		  
+	 <p><strong>Temporary Instructions</strong></p>
+	 <br>
+	 <p><strong>These instructions are for teams starting to use the Toolkit at the DemocracyLab Hackathon on September 10, 2022. 
+	We expect revised instructions to be posted by September 30th. Using these temporary instructions, all members of the Open Meeting Toolkit Baserow group
+	will be able to access your Toolkit data, including STEEPLE Analysis, any contact information you include for team members, and meeting evaluations. 
+	Code for the Carolinas members will only use this information to help you with troubleshooting and to improve the Toolkit, such as revising data types. 
+	We will not analyze your responses or commit to retaining them after December 31, 2022. Keep this in mind when deciding what to include in the Toolkit. 
+	You may want to export your responses and save them locally.</strong>
+		  
           </p>
 
           <p><strong>Prepare Baserow</strong></p>
           <ol>
             <li>Local Team Leaders should make sure that you and/ or at least one member of your team has a <a
-                href="https://baserow.io/" target="_blank">Baserow</a> account. Baserow is free, open source software
-              and the Toolkit is a Baserow template.
+                href="https://baserow.io/" target="_blank">Baserow</a> account and is a member of the Open Meeting Toolkit group. A member of Code for the Carolinas can use your email address to add you to the group and invite you to Baserow. 
+		    Baserow is free, open source software.
             </li>
-            <li><a href="https://baserow.io/user-docs/setting-up-a-group" target="_blank">Set up a Group</a> in Baserow
-              for your team's Open Meeting Toolkit work. Add any team members who want to work in Baserow to your group.
-            </li>
-            <li><a href="https://baserow.io/user-docs/create-a-database" target="_blank">Duplicate</a> the Open Meeting
-              Toolkit database using the three-dot menu.
-              <p><img src="./toolkit-site/assests/how-to-duplicate-the-database-using-the-three-dot-menu.jpg"
+	    <li>Locate the Open Meeting Toolkit database in the sidebar on left side of the screen and <a href="https://baserow.io/user-docs/create-a-database" target="_blank">duplicate</a> it using the three-dot menu.
+              <p><figure><img src="./toolkit-site/assests/how-to-duplicate-the-database-using-the-three-dot-menu.jpg"
                   alt="to duplicate the database click on the three dot menu"></p>
-            </li>
+             <figcaption>Baserow sidebar with Open Meeting Toolkit showing three-dot menu</figcaption>
+		</figure></li>
           </ol>
           <br>
           <p><strong>Fill in STEEPLE Analysis Questions</strong></p>
-          <p>Decide how your team wants to work on the STEEPLE Analysis. Here are three things to consider:</p>
+          <p>Decide how your team wants to work on the STEEPLE Analysis. Here are two things to consider:</p>
           <ol>
             <li>
               Does your team know each other? Lead a round of synchronous or asynchronous introductions to get
               acquainted before you start work on the STEEPLE analysis.
-            </li>
-            <li>
-              Will you work through the whole form together or divide up the questions? Instructions for both approaches
-              are below. The whole team approach may be better if team members want more support with the activity.
-              Dividing the questions, then coming back together to complete the Ethical questions, will probably go
-              faster.
             </li>
             <li>
               How will you collaborate? You may choose to collaborate in a breakout room, in chat, 
@@ -194,37 +183,43 @@ data in any spreadsheet program. Once you have collected the data, export it in 
           <p>The STEEPLE analysis has seven parts. Plan to spend no more than about 10 minutes on each part. You can
             always go back and adjust your responses in Baserow. You will have a text box on the last page of the survey
             (Ethical) where you can include any additional information or clarify your answers.</p>
-<!--To complete the whole form as a team: -->
+<!--To complete the whole form as a team (This is the only option we will recommend at the Hackathon. Commenting out the other option.): -->
           <ol>
-            <p><u><strong>To complete the whole form as a team:</strong></u></p>
             <li>Choose one person to take notes on your team's work.</li>
             <li>From the STEEPLE Analysis table in your database, click on the STEEPLE Social form.
-              <p><img src="./toolkit-site/assests/click-on-STEEPLE-social-form.jpg"
+              <p><figure><img src="./toolkit-site/assests/click-on-STEEPLE-social-form.jpg"
                 alt="click on STEEPLE social form"></p>
-            </li>
+            <figcaption>Baserow STEEPLE Analysis menu showing STEEPLE Social form</figcaption>
+		</figure></li> 
             <li>Use the Share form function to create a link to the STEEPLE Social form. Send that link to the person who will record and submit your team's responses. You may choose to do that yourself as team lead, or have someone else do it. That person does not need a Baserow account.
-              <p><img src="./toolkit-site/assests/share-form-with-team.jpg"
+              <p><figure><img src="./toolkit-site/assests/share-form-with-team.jpg"
                 alt="click on share form to create a link to send to who will record and submit teams responses"></p>
-            </li>
+               <figcaption>Baserow Share form function showing link to share STEEPLE Social form</figcaption>
+		</figure>
+	      </li>
             <li>Complete and submit the pages of the STEEPLE Analysis form in order. While you can't go backward on the form, you can change your responses directly in the STEEPLE Analysis table in Baserow. You can also use the link to generate a new, blank form and complete only the pages you want to change.</li>
           </ol>
+	  
+	  	 <p><strong>Temporary Instructions</strong></p>
+	 <br>
+	 <p><strong>At this time Baserow creates a new row for each part of the STEEPLE form. If you prefer, you can copy and paste organize all data into same row.</strong>
 
 <!--To complete parts of the form as individuals or small teams:-->
-          <br>
+          <!--br>
           <ol>
-            <p><u><strong>To complete parts of the form as individuals or small teams:</strong></u></p>
-            <li>From the STEEPLE Analysis table in your database, click on a STEEPLE form. Use the Share form function to access a link to each form. Send each link to an individual or small team.
-              <p><img src="./toolkit-site/assests/share-form-as-an-individual-or-small-team.jpg"
+            <!--p><u><strong>To complete parts of the form as individuals or small teams:</strong></u></p>
+            <!--li>From the STEEPLE Analysis table in your database, click on a STEEPLE form. Use the Share form function to access a link to each form. Send each link to an individual or small team.
+              <!--p><img src="./toolkit-site/assests/share-form-as-an-individual-or-small-team.jpg"
                 alt="click on share form to create a link to send an individual or small team"></p>
             </li>
-            <li>You might not have seven different people on your team. Here are some suggested ways to group related ways to group forms for smaller teams:
+            <!--li>You might not have seven different people on your team. Here are some suggested ways to group related ways to group forms for smaller teams:
             <ul>
-              <li>Social and Economic (can send the social form only and complete Social and Economic pages)</li>
-              <li>Technical and Environmental</li>
-              <li>Political and Legal</li>
+              <!--li>Social and Economic (can send the social form only and complete Social and Economic pages)</li>
+              <!--li>Technical and Environmental</li>
+              <!--li>Political and Legal</li>
             </ul>
           </li>
-            <li>Even if you work separately on some parts of the analysis, plan to work together to complete the Ethical section.</li>
+            <!--li>Even if you work separately on some parts of the analysis, plan to work together to complete the Ethical section.</li>
           </ol>
         </details>
         

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
       <h3>Instructions for this Toolkit</h3>
 
       <!--Map Instructions-->
-      <!--<details>
+      <details>
         <summary>
           <h3>Add Meetings to the Map</h3>
         </summary>

--- a/meetings.json
+++ b/meetings.json
@@ -230,11 +230,11 @@
         "id": 109
       },
       "geometry": {
-        "longitude": -82.492382,
-        "latitude": 35.587814,
+        "longitude": -82.559814,
+        "latitude": 35.596121,
         "coordinates": [
-          -82.492382,
-          35.587814
+          -82.559814,
+          35.596121
         ],
         "type": "Point"
       },
@@ -290,54 +290,6 @@
     },
     {
       "properties": {
-        "government": "",
-        "publicbody": "",
-        "location": "",
-        "address": "",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "",
-        "id": 112
-      },
-      "geometry": {
-        "longitude": -79.3896838690365,
-        "latitude": 35.5568849207,
-        "coordinates": [
-          -79.3896838690365,
-          35.5568849207
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "",
-        "publicbody": "",
-        "location": "",
-        "address": "",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "",
-        "id": 113
-      },
-      "geometry": {
-        "longitude": -79.3896838690365,
-        "latitude": 35.5568849207,
-        "coordinates": [
-          -79.3896838690365,
-          35.5568849207
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
         "government": "Alamance County",
         "publicbody": "County Commissioners",
         "location": "County Office Building",
@@ -347,7 +299,7 @@
         "end": "",
         "remote": "Video recordings of our Commissioners Meetings both online and on the local Time-Warner Public Access Channels.  The television broadcast of the meetings will occur on the 2nd and 4th Wednesdays of each month at 10 PM.  Online videos will be made available after processing the videos through Youtube, our service providers for multimedia.  The meetings are now streamed live.",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/",
-        "id": 114
+        "id": 112
       },
       "geometry": {
         "longitude": -79.814381,
@@ -371,7 +323,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/adult-care-home-community-advisory-committee/",
-        "id": 115
+        "id": 113
       },
       "geometry": {
         "longitude": -79.451938,
@@ -395,7 +347,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/agricultural-advisory-board/",
-        "id": 116
+        "id": 114
       },
       "geometry": {
         "longitude": -79.487215,
@@ -419,7 +371,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/alamance-beautiful-commission/",
-        "id": 117
+        "id": 115
       },
       "geometry": {
         "longitude": -79.4,
@@ -443,7 +395,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/alamance-community-college-board-of-trustees/",
-        "id": 118
+        "id": 116
       },
       "geometry": {
         "longitude": -79.35742400000001,
@@ -467,7 +419,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/alamance-county-board-of-adjustment/",
-        "id": 119
+        "id": 117
       },
       "geometry": {
         "longitude": -79.4,
@@ -491,7 +443,7 @@
         "end": "",
         "remote": "https://www.youtube.com/channel/UC1QADkhkyUpac9rMs42imjA",
         "moreInfo": "https://www.alamance-nc.com/planningdept/boards/planning-board/",
-        "id": 120
+        "id": 118
       },
       "geometry": {
         "longitude": -79.4,
@@ -515,7 +467,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/senior-services-committee/",
-        "id": 121
+        "id": 119
       },
       "geometry": {
         "longitude": -79.451938,
@@ -539,7 +491,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/alamance-county-transportation-authority/",
-        "id": 122
+        "id": 120
       },
       "geometry": {
         "longitude": -79.814381,
@@ -563,7 +515,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/altamahaw-ossipee-fire-district-commission/",
-        "id": 123
+        "id": 121
       },
       "geometry": {
         "longitude": -79.507246,
@@ -587,7 +539,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/animal-review-board/",
-        "id": 124
+        "id": 122
       },
       "geometry": {
         "longitude": -79.4,
@@ -611,7 +563,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/board-of-equalization-and-review/",
-        "id": 125
+        "id": 123
       },
       "geometry": {
         "longitude": -79.790701,
@@ -635,7 +587,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/healthdept/board-of-health/",
-        "id": 126
+        "id": 124
       },
       "geometry": {
         "longitude": -79.4,
@@ -659,7 +611,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/burlington-board-of-adjustment/",
-        "id": 127
+        "id": 125
       },
       "geometry": {
         "longitude": -79.437799,
@@ -683,7 +635,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/burlington-planning-and-zoning-commission/",
-        "id": 128
+        "id": 126
       },
       "geometry": {
         "longitude": -79.436653,
@@ -707,7 +659,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/burlington-alamance-airport-authority/",
-        "id": 129
+        "id": 127
       },
       "geometry": {
         "longitude": -79.476222,
@@ -731,7 +683,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/e-m-holt-fire-district-commission/",
-        "id": 130
+        "id": 128
       },
       "geometry": {
         "longitude": -79.4,
@@ -755,7 +707,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/ems-peer-review-committee/",
-        "id": 131
+        "id": 129
       },
       "geometry": {
         "longitude": -79.355225,
@@ -779,7 +731,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/eli-whitney-fire-district-commission/",
-        "id": 132
+        "id": 130
       },
       "geometry": {
         "longitude": -79.307239,
@@ -803,7 +755,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/elon-fire-district-commission/",
-        "id": 133
+        "id": 131
       },
       "geometry": {
         "longitude": -79.50669,
@@ -827,7 +779,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/elon-planning-and-zoning-commission/",
-        "id": 134
+        "id": 132
       },
       "geometry": {
         "longitude": -79.50669,
@@ -851,7 +803,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/faucette-fire-district-commission/",
-        "id": 135
+        "id": 133
       },
       "geometry": {
         "longitude": -79.520187,
@@ -875,7 +827,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/gibsonville-board-of-adjustment/",
-        "id": 136
+        "id": 134
       },
       "geometry": {
         "longitude": -79.543097,
@@ -899,7 +851,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/gibsonville-planning-board/",
-        "id": 137
+        "id": 135
       },
       "geometry": {
         "longitude": -79.543097,
@@ -923,7 +875,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/graham-board-of-adjustment/",
-        "id": 138
+        "id": 136
       },
       "geometry": {
         "longitude": -79.4,
@@ -947,7 +899,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/graham-planning-board/",
-        "id": 139
+        "id": 137
       },
       "geometry": {
         "longitude": -79.400576,
@@ -971,7 +923,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/haw-river-fire-district-commission/",
-        "id": 140
+        "id": 138
       },
       "geometry": {
         "longitude": -79.364186,
@@ -995,7 +947,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/haw-river-planning-and-zoning-commission/",
-        "id": 141
+        "id": 139
       },
       "geometry": {
         "longitude": -79.364186,
@@ -1019,7 +971,7 @@
         "end": "",
         "remote": "https://www.youtube.com/channel/UCdav77c1nQtsM1tnx5rr0yQ",
         "moreInfo": "https://www.alamance-nc.com/planningdept/boards/historic-properties-commission/",
-        "id": 142
+        "id": 140
       },
       "geometry": {
         "longitude": -79.4,
@@ -1043,7 +995,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/jury-commission/",
-        "id": 143
+        "id": 141
       },
       "geometry": {
         "longitude": -79.4,
@@ -1067,7 +1019,7 @@
         "end": "9:30 AM",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/justice-advisory-council/",
-        "id": 144
+        "id": 142
       },
       "geometry": {
         "longitude": -79.4,
@@ -1091,7 +1043,7 @@
         "end": "2:00 PM",
         "remote": "Please contact Karen Collins, JCPC Administrative Assistant, kcjcpc@outlook.comfor virtual meeting links.",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/juvenile-crime-prevention-council/",
-        "id": 145
+        "id": 143
       },
       "geometry": {
         "longitude": -79.400576,
@@ -1115,7 +1067,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/library-committee/",
-        "id": 146
+        "id": 144
       },
       "geometry": {
         "longitude": -78.888448,
@@ -1139,7 +1091,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/local-emergency-planning-committee-lepc-for-hazardous-chemicals/",
-        "id": 147
+        "id": 145
       },
       "geometry": {
         "longitude": -79.4,
@@ -1163,7 +1115,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/mebane-board-of-adjustment/",
-        "id": 148
+        "id": 146
       },
       "geometry": {
         "longitude": -79.266962,
@@ -1187,7 +1139,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/mebane-fire-department/",
-        "id": 149
+        "id": 147
       },
       "geometry": {
         "longitude": -79.291313,
@@ -1211,7 +1163,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/mebane-planning-board/",
-        "id": 150
+        "id": 148
       },
       "geometry": {
         "longitude": -79.266962,
@@ -1235,7 +1187,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/north-central-fire-district-commission/",
-        "id": 151
+        "id": 149
       },
       "geometry": {
         "longitude": -79.4,
@@ -1259,7 +1211,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/north-eastern-fire-district-commission/",
-        "id": 152
+        "id": 150
       },
       "geometry": {
         "longitude": -79.4,
@@ -1283,7 +1235,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/nursing-home-community-advisory-committee/",
-        "id": 153
+        "id": 151
       },
       "geometry": {
         "longitude": -79.451938,
@@ -1307,7 +1259,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/public-transit-advisory-commission-ptac/",
-        "id": 154
+        "id": 152
       },
       "geometry": {
         "longitude": -79.4,
@@ -1331,7 +1283,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/recreation/home/recreation-and-parks-commission/",
-        "id": 155
+        "id": 153
       },
       "geometry": {
         "longitude": -79.4,
@@ -1355,7 +1307,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/snow-camp-fire-department/",
-        "id": 156
+        "id": 154
       },
       "geometry": {
         "longitude": -79.43002,
@@ -1379,7 +1331,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/dss/social-services-board/",
-        "id": 157
+        "id": 155
       },
       "geometry": {
         "longitude": -79.4,
@@ -1403,7 +1355,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/swepsonville-fire-district-commission/",
-        "id": 158
+        "id": 156
       },
       "geometry": {
         "longitude": -79.520187,
@@ -1427,7 +1379,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/tourism-development-authority/",
-        "id": 159
+        "id": 157
       },
       "geometry": {
         "longitude": -78.902268,
@@ -1451,7 +1403,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/veterans-service-committee/",
-        "id": 160
+        "id": 158
       },
       "geometry": {
         "longitude": -79.4,
@@ -1475,7 +1427,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/village-of-alamance-planning-board/",
-        "id": 161
+        "id": 159
       },
       "geometry": {
         "longitude": -79.485855,
@@ -1499,7 +1451,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/workforce-development-board/",
-        "id": 162
+        "id": 160
       },
       "geometry": {
         "longitude": -79.485855,
@@ -1507,30 +1459,6 @@
         "coordinates": [
           -79.485855,
           36.035136
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "",
-        "publicbody": "",
-        "location": "",
-        "address": "",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "",
-        "id": 163
-      },
-      "geometry": {
-        "longitude": -79.3896838690365,
-        "latitude": 35.5568849207,
-        "coordinates": [
-          -79.3896838690365,
-          35.5568849207
         ],
         "type": "Point"
       },
@@ -1547,7 +1475,7 @@
         "end": "Varies, usually 09:00 AM or 06:45 PM",
         "remote": "Site states \u0022The meetings are broadcast live on CCNCTV Spectrum Cable Channel 5. The meetings are rebroadcast the Wednesday following the meeting at 7:00 p.m. and Friday following the meeting at 10:30 a.m.\u0022  Recordings are available on Youtube here: https://www.youtube.com/user/CumberlandCountyNC/videos",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/meetings",
-        "id": 164
+        "id": 161
       },
       "geometry": {
         "longitude": -78.83,
@@ -1571,7 +1499,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 165
+        "id": 162
       },
       "geometry": {
         "longitude": -78.798912,
@@ -1595,7 +1523,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 166
+        "id": 163
       },
       "geometry": {
         "longitude": -78.83,
@@ -1619,7 +1547,7 @@
         "end": "Varies",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 167
+        "id": 164
       },
       "geometry": {
         "longitude": -78.974686,
@@ -1643,7 +1571,7 @@
         "end": "Varies",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 168
+        "id": 165
       },
       "geometry": {
         "longitude": -78.885238,
@@ -1667,7 +1595,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 169
+        "id": 166
       },
       "geometry": {
         "longitude": -78.889539,
@@ -1691,7 +1619,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 170
+        "id": 167
       },
       "geometry": {
         "longitude": -78.814741,
@@ -1715,7 +1643,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 171
+        "id": 168
       },
       "geometry": {
         "longitude": -78.83,
@@ -1739,7 +1667,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 172
+        "id": 169
       },
       "geometry": {
         "longitude": -78.83,
@@ -1763,7 +1691,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 173
+        "id": 170
       },
       "geometry": {
         "longitude": -77.925838,
@@ -1787,7 +1715,7 @@
         "end": "Varies",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 174
+        "id": 171
       },
       "geometry": {
         "longitude": -78.83,
@@ -1811,7 +1739,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 175
+        "id": 172
       },
       "geometry": {
         "longitude": -78.83,
@@ -1835,7 +1763,7 @@
         "end": "Varies",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 176
+        "id": 173
       },
       "geometry": {
         "longitude": -78.83,
@@ -1859,7 +1787,7 @@
         "end": "03:15 PM at the latest",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 177
+        "id": 174
       },
       "geometry": {
         "longitude": -78.83,
@@ -1883,7 +1811,7 @@
         "end": "11:00 AM",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 178
+        "id": 175
       },
       "geometry": {
         "longitude": -78.83,
@@ -1907,7 +1835,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 179
+        "id": 176
       },
       "geometry": {
         "longitude": -78.890066,
@@ -1931,7 +1859,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 180
+        "id": 177
       },
       "geometry": {
         "longitude": -78.83,
@@ -1955,7 +1883,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 181
+        "id": 178
       },
       "geometry": {
         "longitude": -78.885238,
@@ -1979,7 +1907,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 182
+        "id": 179
       },
       "geometry": {
         "longitude": -78.874542,
@@ -2003,7 +1931,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 183
+        "id": 180
       },
       "geometry": {
         "longitude": -78.83,
@@ -2027,7 +1955,7 @@
         "end": "4:30 PM",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 184
+        "id": 181
       },
       "geometry": {
         "longitude": -78.9267805,
@@ -2051,7 +1979,7 @@
         "end": "7:00 PM",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 185
+        "id": 182
       },
       "geometry": {
         "longitude": -78.878292,
@@ -2075,14 +2003,14 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 186
+        "id": 183
       },
       "geometry": {
-        "longitude": -78.83,
-        "latitude": 35.05,
+        "longitude": -78.881839,
+        "latitude": 35.056116,
         "coordinates": [
-          -78.83,
-          35.05
+          -78.881839,
+          35.056116
         ],
         "type": "Point"
       },
@@ -2099,7 +2027,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 187
+        "id": 184
       },
       "geometry": {
         "longitude": -78.883411,
@@ -2123,7 +2051,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 188
+        "id": 185
       },
       "geometry": {
         "longitude": -78.83,
@@ -2147,7 +2075,7 @@
         "end": "Varies",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 189
+        "id": 186
       },
       "geometry": {
         "longitude": -78.885238,
@@ -2171,7 +2099,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 190
+        "id": 187
       },
       "geometry": {
         "longitude": -78.83,
@@ -2195,7 +2123,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 191
+        "id": 188
       },
       "geometry": {
         "longitude": -78.987023,
@@ -2219,7 +2147,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 192
+        "id": 189
       },
       "geometry": {
         "longitude": -70.258169,
@@ -2243,7 +2171,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 193
+        "id": 190
       },
       "geometry": {
         "longitude": -78.83,
@@ -2267,7 +2195,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 194
+        "id": 191
       },
       "geometry": {
         "longitude": -78.83,
@@ -2291,7 +2219,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 195
+        "id": 192
       },
       "geometry": {
         "longitude": -78.83,
@@ -2315,7 +2243,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 196
+        "id": 193
       },
       "geometry": {
         "longitude": -77.925838,
@@ -2339,7 +2267,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 197
+        "id": 194
       },
       "geometry": {
         "longitude": -78.83,
@@ -2363,7 +2291,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 198
+        "id": 195
       },
       "geometry": {
         "longitude": -78.885238,
@@ -2371,30 +2299,6 @@
         "coordinates": [
           -78.885238,
           35.057381
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "",
-        "publicbody": "",
-        "location": "",
-        "address": "",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "",
-        "id": 199
-      },
-      "geometry": {
-        "longitude": -79.3896838690365,
-        "latitude": 35.5568849207,
-        "coordinates": [
-          -79.3896838690365,
-          35.5568849207
         ],
         "type": "Point"
       },
@@ -2411,14 +2315,14 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://votedavidsoncountync.com/home-page",
-        "id": 200
+        "id": 196
       },
       "geometry": {
-        "longitude": -80.21,
-        "latitude": 35.79,
+        "longitude": -80.283876,
+        "latitude": 35.840107,
         "coordinates": [
-          -80.21,
-          35.79
+          -80.283876,
+          35.840107
         ],
         "type": "Point"
       },
@@ -2435,7 +2339,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.co.davidson.nc.us/467/Board-of-Health",
-        "id": 201
+        "id": 197
       },
       "geometry": {
         "longitude": -80.059071,
@@ -2459,7 +2363,7 @@
         "end": "6:00 PM",
         "remote": "",
         "moreInfo": "https://www.co.davidson.nc.us/690/Social-Services-Board-Information",
-        "id": 202
+        "id": 198
       },
       "geometry": {
         "longitude": -80.21,
@@ -2483,7 +2387,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "",
-        "id": 203
+        "id": 199
       },
       "geometry": {
         "longitude": -80.21,
@@ -2491,30 +2395,6 @@
         "coordinates": [
           -80.21,
           35.79
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "",
-        "publicbody": "",
-        "location": "",
-        "address": "",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "",
-        "id": 204
-      },
-      "geometry": {
-        "longitude": -79.3896838690365,
-        "latitude": 35.5568849207,
-        "coordinates": [
-          -79.3896838690365,
-          35.5568849207
         ],
         "type": "Point"
       },
@@ -2531,7 +2411,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=2",
-        "id": 205
+        "id": 200
       },
       "geometry": {
         "longitude": -80.26,
@@ -2555,7 +2435,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=75",
-        "id": 206
+        "id": 201
       },
       "geometry": {
         "longitude": -80.280823,
@@ -2579,7 +2459,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=5",
-        "id": 207
+        "id": 202
       },
       "geometry": {
         "longitude": -80.243258,
@@ -2603,7 +2483,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=43",
-        "id": 208
+        "id": 203
       },
       "geometry": {
         "longitude": -80.232435,
@@ -2627,7 +2507,7 @@
         "end": "12:00 PM",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=13",
-        "id": 209
+        "id": 204
       },
       "geometry": {
         "longitude": -80.26,
@@ -2651,7 +2531,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=15",
-        "id": 210
+        "id": 205
       },
       "geometry": {
         "longitude": -80.26,
@@ -2675,7 +2555,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=87",
-        "id": 211
+        "id": 206
       },
       "geometry": {
         "longitude": -80.0999,
@@ -2699,7 +2579,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=44",
-        "id": 212
+        "id": 207
       },
       "geometry": {
         "longitude": -80.2593,
@@ -2723,7 +2603,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=23",
-        "id": 213
+        "id": 208
       },
       "geometry": {
         "longitude": -80.26,
@@ -2747,7 +2627,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=26",
-        "id": 214
+        "id": 209
       },
       "geometry": {
         "longitude": -80.26,
@@ -2771,7 +2651,7 @@
         "end": "9:30 AM",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=86",
-        "id": 215
+        "id": 210
       },
       "geometry": {
         "longitude": -80.26,
@@ -2795,7 +2675,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=29",
-        "id": 216
+        "id": 211
       },
       "geometry": {
         "longitude": -80.243258,
@@ -2819,7 +2699,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=30",
-        "id": 217
+        "id": 212
       },
       "geometry": {
         "longitude": -80.073653,
@@ -2843,7 +2723,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=84",
-        "id": 218
+        "id": 213
       },
       "geometry": {
         "longitude": -80.26,
@@ -2867,7 +2747,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=89",
-        "id": 219
+        "id": 214
       },
       "geometry": {
         "longitude": -80.26,
@@ -2891,7 +2771,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=39",
-        "id": 220
+        "id": 215
       },
       "geometry": {
         "longitude": -80.243258,
@@ -2915,7 +2795,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=40",
-        "id": 221
+        "id": 216
       },
       "geometry": {
         "longitude": -80.073653,
@@ -2939,7 +2819,7 @@
         "end": "",
         "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
         "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=41",
-        "id": 222
+        "id": 217
       },
       "geometry": {
         "longitude": -80.243258,
@@ -2954,7 +2834,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Adult Care Home Community Advisory Committee",
         "location": "JR Kernodle Senior Center",
         "address": "Kernodle Senior Center, 1535 S Mebane St, Burlington, North Carolina 27215, United States",
@@ -2963,7 +2843,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Tracy Warner, Ombudsman, (336) 904-0300",
-        "id": 223
+        "id": 218
       },
       "geometry": {
         "longitude": -79.451938,
@@ -2978,7 +2858,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Alamance County Senior Services Committee",
         "location": "J. R. Kernodle Senior Center",
         "address": "Kernodle Senior Center, 1535 S Mebane St, Burlington, North Carolina 27215, United States",
@@ -2987,7 +2867,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Crystal Norman\u00A0 (336) 904-0300",
-        "id": 224
+        "id": 219
       },
       "geometry": {
         "longitude": -79.451938,
@@ -3002,7 +2882,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Board of Health",
         "location": "Alamance NC",
         "address": "Alamance, North Carolina, United States",
@@ -3011,6 +2891,126 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/board-of-health/",
+        "id": 220
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Nursing Home Community Advisory Committee",
+        "location": "J.R. Kernodle Senior Center",
+        "address": "Kernodle Senior Center, 1535 S Mebane St, Burlington, North Carolina 27215, United States",
+        "schedule": "9:30 a.m. the first Thursday of each quarter",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Tracy Warner, Ombudsman, (336) 904-0300",
+        "id": 221
+      },
+      "geometry": {
+        "longitude": -79.451938,
+        "latitude": 36.080331,
+        "coordinates": [
+          -79.451938,
+          36.080331
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Social Services Board",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/social-services-board/",
+        "id": 222
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Workforce Development Board",
+        "location": "Rotate at Alamance, Orange, or Randolph County",
+        "address": "Randolph County, North Carolina, United States",
+        "schedule": "11:00 a.m. the 3rd Thursday in the 1st month of each quarter",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Tammy Wall 336-629-5141",
+        "id": 223
+      },
+      "geometry": {
+        "longitude": -79.81,
+        "latitude": 35.71,
+        "coordinates": [
+          -79.81,
+          35.71
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Animal Review Board",
+        "location": "",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Sheriff Terry Johnson\u00A0 336-570-6300",
+        "id": 224
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Jury Commission",
+        "location": "",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "September and October as needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Meredith Edwards, Clerk of Court 336-570-5200",
         "id": 225
       },
       "geometry": {
@@ -3026,23 +3026,23 @@
     },
     {
       "properties": {
-        "government": "Alamance",
-        "publicbody": "Nursing Home Community Advisory Committee",
-        "location": "J.R. Kernodle Senior Center",
-        "address": "Kernodle Senior Center, 1535 S Mebane St, Burlington, North Carolina 27215, United States",
-        "schedule": "9:30 a.m. the first Thursday of each quarter",
+        "government": "Alamance County",
+        "publicbody": "Justice Advisory Council",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "Tracy Warner, Ombudsman, (336) 904-0300",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/justice-advisory-council/",
         "id": 226
       },
       "geometry": {
-        "longitude": -79.451938,
-        "latitude": 36.080331,
+        "longitude": -79.485855,
+        "latitude": 36.035136,
         "coordinates": [
-          -79.451938,
-          36.080331
+          -79.485855,
+          36.035136
         ],
         "type": "Point"
       },
@@ -3050,15 +3050,15 @@
     },
     {
       "properties": {
-        "government": "Alamance",
-        "publicbody": "Social Services Board",
+        "government": "Alamance County",
+        "publicbody": "Juvenile Crime Prevention Council",
         "location": "Alamance NC",
         "address": "Alamance, North Carolina, United States",
         "schedule": "",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/social-services-board/",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/juvenile-crime-prevention-council/",
         "id": 227
       },
       "geometry": {
@@ -3074,40 +3074,16 @@
     },
     {
       "properties": {
-        "government": "Alamance",
-        "publicbody": "Workforce Development Board",
-        "location": "Rotate at Alamance, Orange, or Randolph County",
-        "address": "Randolph County, North Carolina, United States",
-        "schedule": "11:00 a.m. the 3rd Thursday in the 1st month of each quarter",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "Tammy Wall 336-629-5141",
-        "id": 228
-      },
-      "geometry": {
-        "longitude": -79.81,
-        "latitude": 35.71,
-        "coordinates": [
-          -79.81,
-          35.71
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Alamance",
-        "publicbody": "Animal Review Board",
-        "location": "",
+        "government": "Alamance County",
+        "publicbody": "LEPC",
+        "location": "Alamance NC",
         "address": "Alamance, North Carolina, United States",
-        "schedule": "As called",
+        "schedule": "",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "Sheriff Terry Johnson\u00A0 336-570-6300",
-        "id": 229
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/local-emergency-planning-committee-lepc-for-hazardous-chemicals/",
+        "id": 228
       },
       "geometry": {
         "longitude": -79.485855,
@@ -3122,15 +3098,39 @@
     },
     {
       "properties": {
-        "government": "Alamance",
-        "publicbody": "Jury Commission",
-        "location": "",
-        "address": "Alamance, North Carolina, United States",
-        "schedule": "September and October as needed",
+        "government": "Alamance County",
+        "publicbody": "Alamance County Board of Adjustment",
+        "location": "Commissioners\u2019 Room",
+        "address": "Country Inn \u0026 Suites by Radisson, 3211 Wilson Dr, Burlington, North Carolina 27215, United States",
+        "schedule": "7:00 p.m. the first Monday of the month when required",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "Meredith Edwards, Clerk of Court 336-570-5200",
+        "moreInfo": "Tonya Caddle 336-570-4052",
+        "id": 229
+      },
+      "geometry": {
+        "longitude": -79.502324,
+        "latitude": 36.068022,
+        "coordinates": [
+          -79.502324,
+          36.068022
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Alamance County Planning Board",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/alamance-county-planning-board/",
         "id": 230
       },
       "geometry": {
@@ -3146,127 +3146,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
-        "publicbody": "Justice Advisory Council",
-        "location": "Alamance NC",
-        "address": "Alamance, North Carolina, United States",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/justice-advisory-council/",
-        "id": 231
-      },
-      "geometry": {
-        "longitude": -79.485855,
-        "latitude": 36.035136,
-        "coordinates": [
-          -79.485855,
-          36.035136
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Alamance",
-        "publicbody": "Juvenile Crime Prevention Council",
-        "location": "Alamance NC",
-        "address": "Alamance, North Carolina, United States",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/juvenile-crime-prevention-council/",
-        "id": 232
-      },
-      "geometry": {
-        "longitude": -79.485855,
-        "latitude": 36.035136,
-        "coordinates": [
-          -79.485855,
-          36.035136
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Alamance",
-        "publicbody": "LEPC",
-        "location": "Alamance NC",
-        "address": "Alamance, North Carolina, United States",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/local-emergency-planning-committee-lepc-for-hazardous-chemicals/",
-        "id": 233
-      },
-      "geometry": {
-        "longitude": -79.485855,
-        "latitude": 36.035136,
-        "coordinates": [
-          -79.485855,
-          36.035136
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Alamance",
-        "publicbody": "Alamance County Board of Adjustment",
-        "location": "Commissioners\u2019 Room",
-        "address": "Country Inn \u0026 Suites by Radisson, 3211 Wilson Dr, Burlington, North Carolina 27215, United States",
-        "schedule": "7:00 p.m. the first Monday of the month when required",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "Tonya Caddle 336-570-4052",
-        "id": 234
-      },
-      "geometry": {
-        "longitude": -79.502324,
-        "latitude": 36.068022,
-        "coordinates": [
-          -79.502324,
-          36.068022
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Alamance",
-        "publicbody": "Alamance County Planning Board",
-        "location": "Alamance NC",
-        "address": "Alamance, North Carolina, United States",
-        "schedule": "",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/alamance-county-planning-board/",
-        "id": 235
-      },
-      "geometry": {
-        "longitude": -79.485855,
-        "latitude": 36.035136,
-        "coordinates": [
-          -79.485855,
-          36.035136
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Board of Equalization and Review",
         "location": "Commissioners\u2019 Meeting Room",
         "address": "Raleigh Marriott Crabtree Valley, 4500 Marriott Drive, Raleigh, North Carolina 27612, United States",
@@ -3275,7 +3155,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Jeremy Akins, Tax Administrator\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-228-1312",
-        "id": 236
+        "id": 231
       },
       "geometry": {
         "longitude": -78.678044,
@@ -3290,7 +3170,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Burlington Board of Adjustment",
         "location": "Burlington City Council Chambers",
         "address": "Burlington, North Carolina, United States",
@@ -3299,7 +3179,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Conrad Olmedo 336-513-5416",
-        "id": 237
+        "id": 232
       },
       "geometry": {
         "longitude": -79.437799,
@@ -3314,23 +3194,23 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Burlington Planning and Zoning Commission",
         "location": "Burlington Municipal Building, Room 202",
-        "address": "Burlington Municipal Building, 425 S Lexington Ave, Burlington, North Carolina 27215, United States",
+        "address": "Alamance Rd, Burlington, North Carolina 27215, United States",
         "schedule": "7:00 p.m. the fourth Monday of each month",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "Conrad Olmedo 336-513-5416",
-        "id": 238
+        "id": 233
       },
       "geometry": {
-        "longitude": -79.436653,
-        "latitude": 36.091335,
+        "longitude": -79.45431,
+        "latitude": 36.06594,
         "coordinates": [
-          -79.436653,
-          36.091335
+          -79.45431,
+          36.06594
         ],
         "type": "Point"
       },
@@ -3338,7 +3218,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Elon Planning and Zoning Commission",
         "location": "Elon Town Hall",
         "address": "Elon, North Carolina, United States",
@@ -3347,7 +3227,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "DiAnne Enoch, Clerk\u00A0 336-584-3601",
-        "id": 239
+        "id": 234
       },
       "geometry": {
         "longitude": -79.50669,
@@ -3362,7 +3242,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Gibsonville Board of Adjustment",
         "location": "Gibsonville Town Hall",
         "address": "Gibsonville Town Hall, Gibsonville, North Carolina 27249, United States",
@@ -3371,7 +3251,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Ben Baxley, Town Manager\u00A0\u00A0 336-449-4144",
-        "id": 240
+        "id": 235
       },
       "geometry": {
         "longitude": -79.543097,
@@ -3386,7 +3266,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Gibsonville Planning Board",
         "location": "Gibsonville Town Hall",
         "address": "Gibsonville Town Hall, Gibsonville, North Carolina 27249, United States",
@@ -3395,7 +3275,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Ben Baxley, Town Manager\u00A0\u00A0 336-449-4144",
-        "id": 241
+        "id": 236
       },
       "geometry": {
         "longitude": -79.543097,
@@ -3410,7 +3290,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Graham Board of Adjustment",
         "location": "",
         "address": "Alamance, North Carolina, United States",
@@ -3419,7 +3299,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Justin Snyder 336-570-6700",
-        "id": 242
+        "id": 237
       },
       "geometry": {
         "longitude": -79.485855,
@@ -3434,7 +3314,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Graham Planning Board",
         "location": "Council Chambers of Graham Municipal Building",
         "address": "Graham, North Carolina, United States",
@@ -3443,7 +3323,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Justin Snyder 336-570-6700",
-        "id": 243
+        "id": 238
       },
       "geometry": {
         "longitude": -79.400576,
@@ -3458,7 +3338,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Haw River Board of Adjustment",
         "location": "Haw River Municipal Building",
         "address": "Haw River, North Carolina, United States",
@@ -3467,7 +3347,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Sean Tencer, Town Manager\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-578-0784",
-        "id": 244
+        "id": 239
       },
       "geometry": {
         "longitude": -79.364186,
@@ -3482,7 +3362,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Haw River Planning and Zoning Commission",
         "location": "Haw River Municipal Building",
         "address": "Haw River, North Carolina, United States",
@@ -3491,7 +3371,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Sean Tencer, Town Manager\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-578-0784",
-        "id": 245
+        "id": 240
       },
       "geometry": {
         "longitude": -79.364186,
@@ -3506,7 +3386,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Historic Properties Commission",
         "location": "Alamance NC",
         "address": "Alamance, North Carolina, United States",
@@ -3515,7 +3395,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/historic-properties-commission/",
-        "id": 246
+        "id": 241
       },
       "geometry": {
         "longitude": -79.485855,
@@ -3530,7 +3410,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Mebane Board of Adjustment",
         "location": "Mebane Municipal Building, City Council Chambers",
         "address": "Mebane, North Carolina, United States",
@@ -3539,7 +3419,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "919-563-9990",
-        "id": 247
+        "id": 242
       },
       "geometry": {
         "longitude": -79.266962,
@@ -3554,7 +3434,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Mebane Planning Board",
         "location": "Mebane Municipal Building, City Council Chambers",
         "address": "Mebane, North Carolina, United States",
@@ -3563,7 +3443,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "919-563-9990",
-        "id": 248
+        "id": 243
       },
       "geometry": {
         "longitude": -79.266962,
@@ -3578,7 +3458,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Village of Alamance Board of Adjustment",
         "location": "Village of Alamance Town Hall",
         "address": "Alamance, North Carolina, United States",
@@ -3587,7 +3467,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Ben York, Clerk\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-226-0033",
-        "id": 249
+        "id": 244
       },
       "geometry": {
         "longitude": -79.485855,
@@ -3602,7 +3482,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Village of Alamance Planning Board",
         "location": "Village of Alamance Town Hall",
         "address": "Alamance, North Carolina, United States",
@@ -3611,7 +3491,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Ben York, Clerk\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-226-0033",
-        "id": 250
+        "id": 245
       },
       "geometry": {
         "longitude": -79.485855,
@@ -3626,7 +3506,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Agricultural Advisory Board / Farmland Preservation",
         "location": "Agricultural Building Auditorium",
         "address": "La Cocina, 309 Huffman Mill Rd, Burlington, North Carolina 27215, United States",
@@ -3635,7 +3515,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Brad Moore\u00A0\u00A0\u00A0\u00A0 336-290-0380",
-        "id": 251
+        "id": 246
       },
       "geometry": {
         "longitude": -79.487215,
@@ -3650,7 +3530,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Alamance Beautiful Commission",
         "location": "Agricultural Extension Center",
         "address": "Center Road, Haw River, North Carolina 27258, United States",
@@ -3659,7 +3539,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "",
-        "id": 252
+        "id": 247
       },
       "geometry": {
         "longitude": -79.355225,
@@ -3674,7 +3554,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Alamance Community College Board of Trustees",
         "location": "Alamance Community College, Wallace Gee Bldg.",
         "address": "Alamance Community College, 1247 Jimmie Kerr Rd, Graham, North Carolina 27253, United States",
@@ -3683,7 +3563,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Dr. Algie C. Gatewood, President\u00A0\u00A0 336-506-4150",
-        "id": 253
+        "id": 248
       },
       "geometry": {
         "longitude": -79.35742400000001,
@@ -3698,7 +3578,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Alamance County Transportation Authority",
         "location": "ACTA Office",
         "address": "Lil Donnie Walkers Car Wash, 3804 S Mebane St, Burlington, North Carolina 27215, United States",
@@ -3707,7 +3587,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Peter Murphy 336-222-0565",
-        "id": 254
+        "id": 249
       },
       "geometry": {
         "longitude": -79.484225,
@@ -3722,7 +3602,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Burlington-Alamance Airport Authority",
         "location": "Airport Terminal Building",
         "address": "Burlington-Alamance Regional Airport, 3441 N Aviation Dr, Burlington, North Carolina 27215, United States",
@@ -3731,7 +3611,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Dan Danieley, Executive Director\u00A0\u00A0\u00A0\u00A0\u00A0 336-227-0771",
-        "id": 255
+        "id": 250
       },
       "geometry": {
         "longitude": -79.476222,
@@ -3746,7 +3626,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Library Committee",
         "location": "One of the four libraries",
         "address": "Durham County Library - South Regional, 4505 S Alston Ave, Durham, North Carolina 27713, United States",
@@ -3755,7 +3635,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Susana Goldman, Director of Alamance County Public Libraries 336-229-3588",
-        "id": 256
+        "id": 251
       },
       "geometry": {
         "longitude": -78.888448,
@@ -3770,7 +3650,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Public Transit Advisory Commission (PTAC)",
         "location": "Alamance NC",
         "address": "Alamance, North Carolina, United States",
@@ -3779,7 +3659,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/public-transit-advisory-commission-ptac/",
-        "id": 257
+        "id": 252
       },
       "geometry": {
         "longitude": -79.485855,
@@ -3794,7 +3674,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Recreation and Parks Commission",
         "location": "Alamance NC",
         "address": "Alamance, North Carolina, United States",
@@ -3803,7 +3683,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/recreation-and-parks-commission/",
-        "id": 258
+        "id": 253
       },
       "geometry": {
         "longitude": -79.485855,
@@ -3818,23 +3698,23 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Tourism Development Authority",
-        "location": "Chamber of Commerce/Visitor Bureau",
-        "address": "Durham Chamber of Commerce, 300 W Morgan St, Durham, North Carolina 27701, United States",
-        "schedule": "10:30 a.m. on the fourth Tuesday of every month.\u00A0 Changes will be posted at https://www.visitalamance.com/about/tourism-development-authority/",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "10:30 a.m. on the fourth Tuesday of every month.",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "Grace VandeViser, Executive Director (336) 570-1444",
-        "id": 259
+        "id": 254
       },
       "geometry": {
-        "longitude": -78.902268,
-        "latitude": 35.99853,
+        "longitude": -79.485855,
+        "latitude": 36.035136,
         "coordinates": [
-          -78.902268,
-          35.99853
+          -79.485855,
+          36.035136
         ],
         "type": "Point"
       },
@@ -3842,7 +3722,7 @@
     },
     {
       "properties": {
-        "government": "Alamance",
+        "government": "Alamance County",
         "publicbody": "Veterans Service Committee",
         "location": "Veterans Service Office",
         "address": "TS Designs, 2053 Willow Spring Ln, Burlington, North Carolina 27215, United States",
@@ -3851,7 +3731,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "Tammy Crawford, Veterans Service Officer\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-570-6763",
-        "id": 260
+        "id": 255
       },
       "geometry": {
         "longitude": -79.486391,
@@ -3866,23 +3746,23 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "A.B.C. Board",
         "location": "ABC Board Office Conference Room \n424 Person Street\nFayetteville, NC",
-        "address": "Person Street, Fayetteville, North Carolina 28301, United States",
+        "address": "424 Person Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Second Monday of each month at 6:00 p.m. The average length of a meeting is approximately two hours.",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 261
+        "id": 256
       },
       "geometry": {
-        "longitude": -78.86733,
-        "latitude": 35.04916,
+        "longitude": -78.870995,
+        "latitude": 35.049355,
         "coordinates": [
-          -78.86733,
-          35.04916
+          -78.870995,
+          35.049355
         ],
         "type": "Point"
       },
@@ -3890,11 +3770,131 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Adult Care Home Community Advisory Committee",
         "location": "Various adult care homes in Cumberland County",
         "address": "Cumberland County, North Carolina, United States",
         "schedule": "Third Thursday of the last month of each quarter at 1:00 p.m. There is an initial training period of 15 hours to include study of a committee handbook and orientation visits to long-term care facilities. Additional training of 10 hours per year is required. Visits in the assigned facilities are of the utmost importance in the participation on this committee. A commitment of at least one day per quarter to visit facilities and 4 hours per quarter for business and training meetings.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 257
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Animal Services Board",
+        "location": "Animal\u00A0Services Department \n4704 Corporation Drive \nFayetteville, NC",
+        "address": "4704 Corporation Drive, Fayetteville, North Carolina 28306, United States",
+        "schedule": "First Monday of every other month (Feb./Apr./June/Aug./Oct./Dec.) at 6:00 p.m. (No meetings held on first or last day of any month.) The average length of a meeting varies.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 258
+      },
+      "geometry": {
+        "longitude": -78.889975,
+        "latitude": 34.955995,
+        "coordinates": [
+          -78.889975,
+          34.955995
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Board of Adjustment",
+        "location": "Historic Cumberland County Courthouse, Hearing Room #3 \n130 Gillespie Street \nFayetteville, NC",
+        "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
+        "schedule": "Third Thursday of each month at 6:00 p.m. The average length of a meeting varies. Each member spends approximately three hours per month in service to this board.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 259
+      },
+      "geometry": {
+        "longitude": -78.87914,
+        "latitude": 35.051535,
+        "coordinates": [
+          -78.87914,
+          35.051535
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Board of Health",
+        "location": "Cumberland County Health Department \nBoard Room \n1235 Ramsey Street \nFayetteville, NC",
+        "address": "1235 Ramsey Street, Fayetteville, North Carolina 28301, United States",
+        "schedule": "Third Tuesday of each month at 6:00 p.m. July and September meetings take place only if desired.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 260
+      },
+      "geometry": {
+        "longitude": -78.88205,
+        "latitude": 35.07386,
+        "coordinates": [
+          -78.88205,
+          35.07386
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cape Fear Valley Health System Board of Trustees",
+        "location": "Cape Fear Valley Health System \nBoard Room First Floor/Administrative Area \n1638 Owen Drive\nFayetteville, NC",
+        "address": "Cape Fear, North Carolina, United States",
+        "schedule": "Last Wednesday of each month at\u00A05:30 p.m. (No April or July Meeting; November \u0026 December meeting combined)",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 261
+      },
+      "geometry": {
+        "longitude": -78.814741,
+        "latitude": 35.42516,
+        "coordinates": [
+          -78.814741,
+          35.42516
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Civic Center Commission",
+        "location": "Cumberland County Civic Center \nCrown Coliseum Board Room \n1960 Coliseum Drive \nFayetteville, NC",
+        "address": "Cumberland County, North Carolina, United States",
+        "schedule": "Fourth Tuesday of each month at 5:30 p.m. The Board is also divided into three subcommittees that meet on a monthly basis: Finance Committee, Capital Improvements Committee, and Marketing and Sales Committee.",
         "start": "",
         "end": "",
         "remote": "",
@@ -3914,127 +3914,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
-        "publicbody": "Animal Services Board",
-        "location": "Animal\u00A0Services Department \n4704 Corporation Drive \nFayetteville, NC",
-        "address": "4704 Corporation Drive, Fayetteville, North Carolina 28306, United States",
-        "schedule": "First Monday of every other month (Feb./Apr./June/Aug./Oct./Dec.) at 6:00 p.m. (No meetings held on first or last day of any month.) The average length of a meeting varies.",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 263
-      },
-      "geometry": {
-        "longitude": -78.889975,
-        "latitude": 34.955995,
-        "coordinates": [
-          -78.889975,
-          34.955995
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Cumberland",
-        "publicbody": "Board of Adjustment",
-        "location": "Historic Cumberland County Courthouse, Hearing Room #3 \n130 Gillespie Street \nFayetteville, NC",
-        "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
-        "schedule": "Third Thursday of each month at 6:00 p.m. The average length of a meeting varies. Each member spends approximately three hours per month in service to this board.",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 264
-      },
-      "geometry": {
-        "longitude": -78.87914,
-        "latitude": 35.051535,
-        "coordinates": [
-          -78.87914,
-          35.051535
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Cumberland",
-        "publicbody": "Board of Health",
-        "location": "Cumberland County Health Department \nBoard Room \n1235 Ramsey Street \nFayetteville, NC",
-        "address": "Ramsey Street, Fayetteville, North Carolina 28311, United States",
-        "schedule": "Third Tuesday of each month at 6:00 p.m. July and September meetings take place only if desired.",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 265
-      },
-      "geometry": {
-        "longitude": -78.85364,
-        "latitude": 35.16869,
-        "coordinates": [
-          -78.85364,
-          35.16869
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Cumberland",
-        "publicbody": "Cape Fear Valley Health System Board of Trustees",
-        "location": "Cape Fear Valley Health System \nBoard Room First Floor/Administrative Area \n1638 Owen Drive\nFayetteville, NC",
-        "address": "Cape Fear, North Carolina, United States",
-        "schedule": "Last Wednesday of each month at\u00A05:30 p.m. (No April or July Meeting; November \u0026 December meeting combined)",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 266
-      },
-      "geometry": {
-        "longitude": -78.814741,
-        "latitude": 35.42516,
-        "coordinates": [
-          -78.814741,
-          35.42516
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Cumberland",
-        "publicbody": "Civic Center Commission",
-        "location": "Cumberland County Civic Center \nCrown Coliseum Board Room \n1960 Coliseum Drive \nFayetteville, NC",
-        "address": "Cumberland County, North Carolina, United States",
-        "schedule": "Fourth Tuesday of each month at 5:30 p.m. The Board is also divided into three subcommittees that meet on a monthly basis: Finance Committee, Capital Improvements Committee, and Marketing and Sales Committee.",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 267
-      },
-      "geometry": {
-        "longitude": -78.83,
-        "latitude": 35.05,
-        "coordinates": [
-          -78.83,
-          35.05
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Cemetery Commission",
         "location": "As called",
         "address": "Cumberland Street, Newport, North Carolina 28570, United States",
@@ -4043,7 +3923,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 268
+        "id": 263
       },
       "geometry": {
         "longitude": -76.98508,
@@ -4058,7 +3938,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Community Child Protection/Fatality Prevention Team",
         "location": "Department of Social Services Building\n4th Floor, Room 440 \n1225 Ramsey Street\nFayetteville, NC",
         "address": "1225 Ramsey Street, Fayetteville, North Carolina 28301, United States",
@@ -4067,7 +3947,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 269
+        "id": 264
       },
       "geometry": {
         "longitude": -78.88209,
@@ -4082,7 +3962,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Finance Corporation",
         "location": "Cumberland County Courthouse, Room 564 \n117 Dick Street \nFayetteville, NC",
         "address": "117 Dick Street, Fayetteville, North Carolina 28301, United States",
@@ -4091,7 +3971,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 270
+        "id": 265
       },
       "geometry": {
         "longitude": -78.87624,
@@ -4106,7 +3986,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Home and Community Care Block Grant Committee",
         "location": "Various service provider locations within Cumberland County",
         "address": "CenturyLink, 717 Mcgilvary St, Fayetteville, North Carolina 28301, United States",
@@ -4115,7 +3995,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 271
+        "id": 266
       },
       "geometry": {
         "longitude": -78.890066,
@@ -4130,7 +4010,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Industrial Facilities and Pollution Control Financing Authority",
         "location": "Cumberland County Courthouse, \nRoom 564 \n117 Dick Street \nFayetteville, NC",
         "address": "117 Dick Street, Fayetteville, North Carolina 28301, United States",
@@ -4139,7 +4019,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 272
+        "id": 267
       },
       "geometry": {
         "longitude": -78.87624,
@@ -4154,23 +4034,23 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Juvenile Crime Prevention Council",
         "location": "Cumberland County CommuniCare, \nLower Level Conference Room \n109 Bradford Ave \nFayetteville, NC 28301",
-        "address": "Bradford Avenue, Fayetteville, North Carolina 28301, United States",
+        "address": "109 Bradford Avenue, Fayetteville, North Carolina 28301, United States",
         "schedule": "Second Wednesday of each month at 1:15 p.m. Meetings are normally one to two hours in length.",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 273
+        "id": 268
       },
       "geometry": {
-        "longitude": -78.89288,
-        "latitude": 35.05289,
+        "longitude": -78.89155,
+        "latitude": 35.055465,
         "coordinates": [
-          -78.89288,
-          35.05289
+          -78.89155,
+          35.055465
         ],
         "type": "Point"
       },
@@ -4178,7 +4058,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Local Emergency Planning Committee",
         "location": "Rotating Locations",
         "address": "Cumberland Street, Newport, North Carolina 28570, United States",
@@ -4187,7 +4067,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 274
+        "id": 269
       },
       "geometry": {
         "longitude": -76.98508,
@@ -4202,23 +4082,23 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Cumberland County Workforce Development Board",
         "location": "FTCC General Classroom Building\nRoom 114\n2817 Ft. Bragg Rd",
-        "address": "Soldier Support Center, 4-2843 Normandy Dr # 284-28433, Fort Bragg, North Carolina 28307, United States",
+        "address": "2817 Fort Bragg Road, Fayetteville, North Carolina 28303, United States",
         "schedule": "Third Tuesday\u00A0of every other month at 11:00\u00A0a.m. (starting in January)",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 275
+        "id": 270
       },
       "geometry": {
-        "longitude": -79.001217,
-        "latitude": 35.139046,
+        "longitude": -78.92591,
+        "latitude": 35.07065,
         "coordinates": [
-          -79.001217,
-          35.139046
+          -78.92591,
+          35.07065
         ],
         "type": "Point"
       },
@@ -4226,7 +4106,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Equalization and Review Board",
         "location": "Cumberland County Courthouse, \nRoom 564 \n117 Dick Street \nFayetteville, NC",
         "address": "117 Dick Street, Fayetteville, North Carolina 28301, United States",
@@ -4235,7 +4115,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 276
+        "id": 271
       },
       "geometry": {
         "longitude": -78.87624,
@@ -4250,7 +4130,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Farm Advisory Board",
         "location": "Historic Cumberland County Courthouse, \nRoom 107C \n130 Gillespie Street \nFayetteville, NC",
         "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
@@ -4259,7 +4139,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 277
+        "id": 272
       },
       "geometry": {
         "longitude": -78.87914,
@@ -4274,7 +4154,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Fayetteville Area Convention and Visitors Bureau Board of Directors",
         "location": "Fayetteville Area Convention and Visitors Bureau \nBoard Room\n245 Person Street\n\nFayetteville, NC",
         "address": "Fayetteville Area Convention and Visitors Bureau, 245 Person St, Fayetteville, North Carolina 28301, United States",
@@ -4283,7 +4163,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 278
+        "id": 273
       },
       "geometry": {
         "longitude": -78.874542,
@@ -4298,7 +4178,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Fayetteville Cumberland County Economic Development Corporation",
         "location": "201 Hay Street\nR. B. Williams Building Ste 401A\nFayetteville, NC",
         "address": "Fayetteville, North Carolina, United States",
@@ -4307,7 +4187,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 279
+        "id": 274
       },
       "geometry": {
         "longitude": -78.878292,
@@ -4322,7 +4202,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Fayetteville Technical Community College Board of Trustees",
         "location": "Fayetteville Technical Community College, \nBoard Room Tony Rand Student Center \n2201 Hull Road \nFayetteville, NC",
         "address": "Fayetteville, North Carolina, United States",
@@ -4331,7 +4211,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 280
+        "id": 275
       },
       "geometry": {
         "longitude": -78.878292,
@@ -4346,7 +4226,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Fayetteville-Cumberland Parks and Recreation Advisory Commission",
         "location": "City of Fayetteville Parks \u0026 Recreation\n121 Lamon Street \nFayetteville, NC",
         "address": "121 Lamon Street, Fayetteville, North Carolina 28301, United States",
@@ -4355,7 +4235,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 281
+        "id": 276
       },
       "geometry": {
         "longitude": -78.87519,
@@ -4370,7 +4250,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Human Relations Commission",
         "location": "Festival Park Plaza Training Room 1st Floor\n225 Ray Ave\nFayetteville, NC 28301",
         "address": "225 Ray Avenue, Fayetteville, North Carolina 28301, United States",
@@ -4379,7 +4259,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 282
+        "id": 277
       },
       "geometry": {
         "longitude": -78.88183,
@@ -4394,7 +4274,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Joint Appearance Commission",
         "location": "Fayetteville City Hall\nE.E. Smith Conference Room",
         "address": "Fayetteville, North Carolina, United States",
@@ -4403,7 +4283,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 283
+        "id": 278
       },
       "geometry": {
         "longitude": -78.878292,
@@ -4418,7 +4298,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Joint Fort Bragg \u0026 Cumberland County Food Policy Council",
         "location": "1235 Ramsey Street, Fayetteville, NC",
         "address": "1235 Ramsey Street, Fayetteville, North Carolina 28301, United States",
@@ -4427,7 +4307,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 284
+        "id": 279
       },
       "geometry": {
         "longitude": -78.88205,
@@ -4442,7 +4322,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Joint Planning Board",
         "location": "Historic Cumberland County Courthouse\nHearing Room #3 \n130 Gillespie Street \nFayetteville, North Carolina",
         "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
@@ -4451,7 +4331,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 285
+        "id": 280
       },
       "geometry": {
         "longitude": -78.87914,
@@ -4466,7 +4346,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Jury Commission",
         "location": "Judge E. Maurice Braswell Courthouse \n3rd Floor \n117 Dick Street, Fayetteville",
         "address": "Fayetteville, North Carolina, United States",
@@ -4475,7 +4355,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 286
+        "id": 281
       },
       "geometry": {
         "longitude": -78.878292,
@@ -4490,7 +4370,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Library Board of Trustees",
         "location": "Various libraries throughout the County",
         "address": "The Country, Burlington, North Carolina, United States",
@@ -4499,7 +4379,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 287
+        "id": 282
       },
       "geometry": {
         "longitude": -79.5178,
@@ -4514,7 +4394,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Mid-Carolina Aging Advisory Council",
         "location": "Various locations in the three county region (Cumberland, Harnett and Sampson counties)",
         "address": "Sampson County, North Carolina, United States",
@@ -4523,7 +4403,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 288
+        "id": 283
       },
       "geometry": {
         "longitude": -78.37,
@@ -4538,7 +4418,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "North Carolina Southeast",
         "location": "70 West Broad Street, Elizabethtown, NC",
         "address": "70 West Broad Street, Elizabethtown, North Carolina 28337, United States",
@@ -4547,7 +4427,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 289
+        "id": 284
       },
       "geometry": {
         "longitude": -78.605956,
@@ -4562,7 +4442,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Nursing Home Advisory Board",
         "location": "Various nursing homes in Cumberland County",
         "address": "Cumberland County, North Carolina, United States",
@@ -4571,7 +4451,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 290
+        "id": 285
       },
       "geometry": {
         "longitude": -78.83,
@@ -4586,23 +4466,23 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Senior Citizens Advisory Commission",
         "location": "FCPR Senior Center, Large Program Room\n739 Blue Street\nFayetteville, NC",
-        "address": "Blue Street, Fayetteville, North Carolina 28301, United States",
+        "address": "739 Blue Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Second Tuesday of each month at 2:30 p.m.",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 291
+        "id": 286
       },
       "geometry": {
-        "longitude": -78.89206,
-        "latitude": 35.06488,
+        "longitude": -78.89218,
+        "latitude": 35.06403,
         "coordinates": [
-          -78.89206,
-          35.06488
+          -78.89218,
+          35.06403
         ],
         "type": "Point"
       },
@@ -4610,23 +4490,23 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Social Services Board",
         "location": "Department of Social Services, \nBoard Room \n1225 Ramsey Street\nFayetteville, NC",
-        "address": "Ramsey Street, Fayetteville, North Carolina 28311, United States",
+        "address": "1225 Ramsey Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Last Wednesday of each month at 1:00 p.m.",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 292
+        "id": 287
       },
       "geometry": {
-        "longitude": -78.85364,
-        "latitude": 35.16869,
+        "longitude": -78.88209,
+        "latitude": 35.07162,
         "coordinates": [
-          -78.85364,
-          35.16869
+          -78.88209,
+          35.07162
         ],
         "type": "Point"
       },
@@ -4634,7 +4514,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Southeastern Economic Development Commission",
         "location": "707 West Broad Street, \nElizabethtown, NC",
         "address": "707 West Broad Street, Elizabethtown, North Carolina 28337, United States",
@@ -4643,7 +4523,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 293
+        "id": 288
       },
       "geometry": {
         "longitude": -78.613504,
@@ -4658,7 +4538,7 @@
     },
     {
       "properties": {
-        "government": "Cumberland",
+        "government": "Cumberland County",
         "publicbody": "Transportation Advisory Board",
         "location": "Historic Cumberland County Courthouse \nHearing Room #3\n130 Gillespie Street \nFayetteville, NC",
         "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
@@ -4667,7 +4547,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": 294
+        "id": 289
       },
       "geometry": {
         "longitude": -78.87914,
@@ -4682,151 +4562,7 @@
     },
     {
       "properties": {
-        "government": "New Hannover",
-        "publicbody": "Board of Commissioners Agenda Review",
-        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
-        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
-        "schedule": "2022-09-15T16:00:00",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-82/",
-        "id": 295
-      },
-      "geometry": {
-        "longitude": -77.867841,
-        "latitude": 34.24198,
-        "coordinates": [
-          -77.867841,
-          34.24198
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "New Hannover",
-        "publicbody": "Board of Commissioners Regular Meeting",
-        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
-        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
-        "schedule": "2022-09-19T09:00:00",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-159/",
-        "id": 296
-      },
-      "geometry": {
-        "longitude": -77.945692,
-        "latitude": 34.23618,
-        "coordinates": [
-          -77.945692,
-          34.23618
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "New Hannover",
-        "publicbody": "Board of Commissioners Agenda Review",
-        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
-        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
-        "schedule": "2022-09-29T16:00:00",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-81/",
-        "id": 297
-      },
-      "geometry": {
-        "longitude": -77.867841,
-        "latitude": 34.24198,
-        "coordinates": [
-          -77.867841,
-          34.24198
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "New Hannover",
-        "publicbody": "Board of Commissioners Regular Meeting",
-        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
-        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
-        "schedule": "2022-10-03T16:00:00",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-160/",
-        "id": 298
-      },
-      "geometry": {
-        "longitude": -77.945692,
-        "latitude": 34.23618,
-        "coordinates": [
-          -77.945692,
-          34.23618
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "New Hannover",
-        "publicbody": "Board of Commissioners Agenda Review",
-        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
-        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
-        "schedule": "2022-10-13T16:00:00",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-83/",
-        "id": 299
-      },
-      "geometry": {
-        "longitude": -77.867841,
-        "latitude": 34.24198,
-        "coordinates": [
-          -77.867841,
-          34.24198
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "New Hannover",
-        "publicbody": "Board of Commissioners Regular Meeting",
-        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
-        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
-        "schedule": "2022-10-17T09:00:00",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-161/",
-        "id": 300
-      },
-      "geometry": {
-        "longitude": -77.945692,
-        "latitude": 34.23618,
-        "coordinates": [
-          -77.945692,
-          34.23618
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "New Hannover",
+        "government": "New Hannover County",
         "publicbody": "Board of Commissioners Agenda Review",
         "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
         "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
@@ -4835,14 +4571,14 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-84/",
-        "id": 301
+        "id": 290
       },
       "geometry": {
-        "longitude": -77.867841,
-        "latitude": 34.24198,
+        "longitude": -77.868156,
+        "latitude": 34.2416,
         "coordinates": [
-          -77.867841,
-          34.24198
+          -77.868156,
+          34.2416
         ],
         "type": "Point"
       },
@@ -4850,7 +4586,7 @@
     },
     {
       "properties": {
-        "government": "New Hannover",
+        "government": "New Hannover County",
         "publicbody": "Board of Commissioners Regular Meeting",
         "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
         "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
@@ -4859,7 +4595,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-162/",
-        "id": 302
+        "id": 291
       },
       "geometry": {
         "longitude": -77.945692,
@@ -4874,7 +4610,7 @@
     },
     {
       "properties": {
-        "government": "New Hannover",
+        "government": "New Hannover County",
         "publicbody": "Board of Commissioners Agenda Review",
         "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
         "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
@@ -4883,14 +4619,14 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-85/",
-        "id": 303
+        "id": 292
       },
       "geometry": {
-        "longitude": -77.867841,
-        "latitude": 34.24198,
+        "longitude": -77.868156,
+        "latitude": 34.2416,
         "coordinates": [
-          -77.867841,
-          34.24198
+          -77.868156,
+          34.2416
         ],
         "type": "Point"
       },
@@ -4898,7 +4634,7 @@
     },
     {
       "properties": {
-        "government": "New Hannover",
+        "government": "New Hannover County",
         "publicbody": "Board of Commissioners Regular Meeting",
         "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
         "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
@@ -4907,7 +4643,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-163/",
-        "id": 304
+        "id": 293
       },
       "geometry": {
         "longitude": -77.945692,
@@ -4922,7 +4658,7 @@
     },
     {
       "properties": {
-        "government": "Avery",
+        "government": "Avery County",
         "publicbody": "Veterans Day - County Offices Closed",
         "location": "VEVENT",
         "address": "Avery Street, Morehead City, North Carolina 28557, United States",
@@ -4931,7 +4667,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "",
-        "id": 305
+        "id": 294
       },
       "geometry": {
         "longitude": -76.72044,
@@ -4946,7 +4682,7 @@
     },
     {
       "properties": {
-        "government": "Avery",
+        "government": "Avery County",
         "publicbody": "Thanksgiving Holiday - County Offices Closed",
         "location": "VEVENT",
         "address": "Avery Street, Morehead City, North Carolina 28557, United States",
@@ -4955,7 +4691,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "",
-        "id": 306
+        "id": 295
       },
       "geometry": {
         "longitude": -76.72044,
@@ -4970,7 +4706,7 @@
     },
     {
       "properties": {
-        "government": "Avery",
+        "government": "Avery County",
         "publicbody": "Christmas Holiday - County Offices Closed",
         "location": "VEVENT",
         "address": "Avery Street, Morehead City, North Carolina 28557, United States",
@@ -4979,7 +4715,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "",
-        "id": 307
+        "id": 296
       },
       "geometry": {
         "longitude": -76.72044,
@@ -4994,7 +4730,7 @@
     },
     {
       "properties": {
-        "government": "Avery",
+        "government": "Avery County",
         "publicbody": "Christmas Holiday - County Offices Closed",
         "location": "VEVENT",
         "address": "Avery Street, Morehead City, North Carolina 28557, United States",
@@ -5003,7 +4739,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "",
-        "id": 308
+        "id": 297
       },
       "geometry": {
         "longitude": -76.72044,
@@ -5018,7 +4754,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Adult Care Home Community Advisory Committee",
         "location": "Seymour Center",
         "address": "Orange, North Carolina, United States",
@@ -5027,7 +4763,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=47",
-        "id": 309
+        "id": 298
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5042,7 +4778,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Advisory Board on Aging",
         "location": "Passmore Center \u0026 Seymour Center (altnernating)",
         "address": "North Carolina, United States",
@@ -5051,14 +4787,14 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=34",
-        "id": 310
+        "id": 299
       },
       "geometry": {
         "longitude": -79.3896838690365,
-        "latitude": 35.5568849207,
+        "latitude": 35.5568849207634,
         "coordinates": [
           -79.3896838690365,
-          35.5568849207
+          35.5568849207634
         ],
         "type": "Point"
       },
@@ -5066,7 +4802,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Affordable Housing Advisory Board",
         "location": "",
         "address": "Orange, North Carolina, United States",
@@ -5075,7 +4811,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=990744288",
-        "id": 311
+        "id": 300
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5090,7 +4826,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Agricultural Preservation Board",
         "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
         "address": "Davis, North Carolina, United States",
@@ -5099,7 +4835,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=25",
-        "id": 312
+        "id": 301
       },
       "geometry": {
         "longitude": -76.460199,
@@ -5114,7 +4850,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Alcoholic Beverage Control Board",
         "location": "601 Valley Forge Road, Hillsborough",
         "address": "601 Valley Forge Road, Hillsborough, North Carolina 27278, United States",
@@ -5123,7 +4859,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=38",
-        "id": 313
+        "id": 302
       },
       "geometry": {
         "longitude": -79.087285,
@@ -5138,7 +4874,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Animal Services Advisory Board",
         "location": "Community Room of the Animal Services Facility",
         "address": "I-73 S/ US Hwy 220 Rest Stop, I-73 South, Seagrove, North Carolina 27341, United States",
@@ -5147,7 +4883,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144669",
-        "id": 314
+        "id": 303
       },
       "geometry": {
         "longitude": -79.784458,
@@ -5162,7 +4898,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Animal Services Hearing Panel Pool",
         "location": "TBD",
         "address": "Orange, North Carolina, United States",
@@ -5171,7 +4907,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144711",
-        "id": 315
+        "id": 304
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5186,7 +4922,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Arts Commission",
         "location": "Alternating",
         "address": "Orange, North Carolina, United States",
@@ -5195,7 +4931,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=49",
-        "id": 316
+        "id": 305
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5210,7 +4946,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Board of Equalization and Review (REQUIRES DISCLOSURE STATEMENT)",
         "location": "TBD",
         "address": "Orange, North Carolina, United States",
@@ -5219,7 +4955,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=52",
-        "id": 317
+        "id": 306
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5234,7 +4970,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Board of Health",
         "location": "C.H. \u0026 Hillsborough Health Depts. (alternating)",
         "address": "Hillsborough, North Carolina, United States",
@@ -5243,7 +4979,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=7",
-        "id": 318
+        "id": 307
       },
       "geometry": {
         "longitude": -79.099228,
@@ -5258,7 +4994,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Board of Social Services",
         "location": "Hillsborough Commons Board Room",
         "address": "Hillsborough, North Carolina, United States",
@@ -5267,7 +5003,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=11",
-        "id": 319
+        "id": 308
       },
       "geometry": {
         "longitude": -79.099228,
@@ -5282,7 +5018,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Carrboro Board of Adjustment",
         "location": "Carrboro Town Hall",
         "address": "Carrboro Town Hall, 301 W Main St, Carrboro, North Carolina 27510, United States",
@@ -5291,7 +5027,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=17",
-        "id": 320
+        "id": 309
       },
       "geometry": {
         "longitude": -79.077495,
@@ -5306,7 +5042,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Carrboro Northern Transition Area Advisory Committee",
         "location": "TBD",
         "address": "Orange, North Carolina, United States",
@@ -5315,7 +5051,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=64",
-        "id": 321
+        "id": 310
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5330,7 +5066,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Carrboro Planning Board",
         "location": "Carrboro Town Hall",
         "address": "Carrboro Town Hall, 301 W Main St, Carrboro, North Carolina 27510, United States",
@@ -5339,7 +5075,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=15",
-        "id": 322
+        "id": 311
       },
       "geometry": {
         "longitude": -79.077495,
@@ -5354,7 +5090,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Chapel Hill Board of Adjustment",
         "location": "Chapel Hill Town Hall",
         "address": "Chapel Hill, North Carolina, United States",
@@ -5363,7 +5099,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=24",
-        "id": 323
+        "id": 312
       },
       "geometry": {
         "longitude": -79.05578,
@@ -5378,23 +5114,23 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Chapel Hill Library Advisory Board",
         "location": "Chapel Hill Public Library Meeting Room C",
-        "address": "Chapel Hill Public Library, 100 Library Dr, Chapel Hill, North Carolina 27514, United States",
+        "address": "Meeting Street, Chapel Hill, North Carolina 27516, United States",
         "schedule": "5:30 pm Second Monday in Feb, May, Sep, \u0026 Nov",
         "start": "",
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144701",
-        "id": 324
+        "id": 313
       },
       "geometry": {
-        "longitude": -79.035588,
-        "latitude": 35.932167,
+        "longitude": -79.0634775,
+        "latitude": 35.884595,
         "coordinates": [
-          -79.035588,
-          35.932167
+          -79.0634775,
+          35.884595
         ],
         "type": "Point"
       },
@@ -5402,7 +5138,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Chapel Hill Orange County Visitors Bureau Advisory Board",
         "location": "Varies",
         "address": "Orange, North Carolina, United States",
@@ -5411,7 +5147,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=6",
-        "id": 325
+        "id": 314
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5426,7 +5162,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Chapel Hill Parks, Greenways and Recreation Commission",
         "location": "Chapel Hill Public Library",
         "address": "Chapel Hill Public Library, 100 Library Dr, Chapel Hill, North Carolina 27514, United States",
@@ -5435,7 +5171,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144672",
-        "id": 326
+        "id": 315
       },
       "geometry": {
         "longitude": -79.035588,
@@ -5450,7 +5186,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Chapel Hill Planning Commission",
         "location": "Chapel Hill Town Council",
         "address": "Chapel Hill, North Carolina, United States",
@@ -5459,6 +5195,270 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=13",
+        "id": 316
+      },
+      "geometry": {
+        "longitude": -79.05578,
+        "latitude": 35.913154,
+        "coordinates": [
+          -79.05578,
+          35.913154
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Commission for the Environment",
+        "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
+        "address": "Davis, North Carolina, United States",
+        "schedule": "7:00 pm Second Monday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=54",
+        "id": 317
+      },
+      "geometry": {
+        "longitude": -76.460199,
+        "latitude": 34.797385,
+        "coordinates": [
+          -76.460199,
+          34.797385
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Durham Technical Community College Board of Trustees",
+        "location": "Lyon Board Room, Durham Tech Main Campus",
+        "address": "Durham, North Carolina, United States",
+        "schedule": "3:00 pm Varies",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144690",
+        "id": 318
+      },
+      "geometry": {
+        "longitude": -78.901805,
+        "latitude": 35.996653,
+        "coordinates": [
+          -78.901805,
+          35.996653
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Economic Development Advisory Board (REQUIRES DISCLOSURE STATEMENT)",
+        "location": "Rotating",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "12:00 pm Second Tuesday of every other month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144706",
+        "id": 319
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Hillsborough Board of Adjustment",
+        "location": "Hillsborough Town Hall Annex",
+        "address": "Hillsborough, North Carolina, United States",
+        "schedule": "7:00 pm Second  Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=50",
+        "id": 320
+      },
+      "geometry": {
+        "longitude": -79.099228,
+        "latitude": 36.07523,
+        "coordinates": [
+          -79.099228,
+          36.07523
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Hillsborough Planning Board",
+        "location": "Hillsborough Town Hall Annex",
+        "address": "Hillsborough, North Carolina, United States",
+        "schedule": "7:00 pm Third Thursday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=42",
+        "id": 321
+      },
+      "geometry": {
+        "longitude": -79.099228,
+        "latitude": 36.07523,
+        "coordinates": [
+          -79.099228,
+          36.07523
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Historic Preservation Commission (APPLICANTS SHALL RESIDE WITHIN THE TERRITORIAL JURISDICTION OF ORANGE COUNTY)",
+        "location": "Old Orange County Courthouse",
+        "address": "Orange County Courthouse, 106 E Margaret Ln, Hillsborough, North Carolina 27278, United States",
+        "schedule": "7:00 pm Fourth Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=53",
+        "id": 322
+      },
+      "geometry": {
+        "longitude": -79.099206,
+        "latitude": 36.0745765,
+        "coordinates": [
+          -79.099206,
+          36.0745765
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Human Relations Commission",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:00 pm Fourth Tuesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=16",
+        "id": 323
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Jury Commission",
+        "location": "Orange County Courthouse",
+        "address": "Orange County Courthouse, 106 E Margaret Ln, Hillsborough, North Carolina 27278, United States",
+        "schedule": "As needed As needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=10",
+        "id": 324
+      },
+      "geometry": {
+        "longitude": -79.099206,
+        "latitude": 36.0745765,
+        "coordinates": [
+          -79.099206,
+          36.0745765
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Mebane Board of Adjustment",
+        "location": "Mebane Town Hall",
+        "address": "Mebane, North Carolina, United States",
+        "schedule": "6:00 pm First Monday of every month (if necessary)",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=26",
+        "id": 325
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Mebane Planning Board",
+        "location": "Mebane Town Hall",
+        "address": "Mebane, North Carolina, United States",
+        "schedule": "6:30 pm Second Monday of every month (if necessary)",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=32",
+        "id": 326
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Nursing Home Community Advisory Committee",
+        "location": "Seymour Center, 2551 Homestead Rd., Chapel Hill",
+        "address": "Chapel Hill, North Carolina, United States",
+        "schedule": "5:30 pm First Tuesday of every other month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=4",
         "id": 327
       },
       "geometry": {
@@ -5474,47 +5474,47 @@
     },
     {
       "properties": {
-        "government": "Orange",
-        "publicbody": "Commission for the Environment",
-        "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
-        "address": "Davis, North Carolina, United States",
+        "government": "Orange County",
+        "publicbody": "Opioid Advisory Committee",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "TBD TBD",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144721",
+        "id": 328
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange County",
+        "publicbody": "Orange County Board of Adjustment (REQUIRES DISCLOSURE STATEMENT)",
+        "location": "Whitted Building, Room 230",
+        "address": "Orange Street, Beaufort, North Carolina 28516, United States",
         "schedule": "7:00 pm Second Monday of every month",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=54",
-        "id": 328
-      },
-      "geometry": {
-        "longitude": -76.460199,
-        "latitude": 34.797385,
-        "coordinates": [
-          -76.460199,
-          34.797385
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Durham Technical Community College Board of Trustees",
-        "location": "Lyon Board Room, Durham Tech Main Campus",
-        "address": "Durham, North Carolina, United States",
-        "schedule": "3:00 pm Varies",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144690",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=46",
         "id": 329
       },
       "geometry": {
-        "longitude": -78.901805,
-        "latitude": 35.996653,
+        "longitude": -76.66512,
+        "latitude": 34.72012,
         "coordinates": [
-          -78.901805,
-          35.996653
+          -76.66512,
+          34.72012
         ],
         "type": "Point"
       },
@@ -5522,15 +5522,15 @@
     },
     {
       "properties": {
-        "government": "Orange",
-        "publicbody": "Economic Development Advisory Board (REQUIRES DISCLOSURE STATEMENT)",
-        "location": "Rotating",
+        "government": "Orange County",
+        "publicbody": "Orange County Housing Authority",
+        "location": "Southern Human Services Center",
         "address": "Orange, North Carolina, United States",
-        "schedule": "12:00 pm Second Tuesday of every other month",
+        "schedule": "6:00 pm Third Wednesday of every month",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144706",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144698",
         "id": 330
       },
       "geometry": {
@@ -5546,23 +5546,23 @@
     },
     {
       "properties": {
-        "government": "Orange",
-        "publicbody": "Hillsborough Board of Adjustment",
-        "location": "Hillsborough Town Hall Annex",
-        "address": "Hillsborough, North Carolina, United States",
-        "schedule": "7:00 pm Second  Wednesday of every month",
+        "government": "Orange County",
+        "publicbody": "Orange County Parks and Recreation Council",
+        "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
+        "address": "Davis, North Carolina, United States",
+        "schedule": "6:30 pm First Wednesday of every month",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=50",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=44",
         "id": 331
       },
       "geometry": {
-        "longitude": -79.099228,
-        "latitude": 36.07523,
+        "longitude": -76.460199,
+        "latitude": 34.797385,
         "coordinates": [
-          -79.099228,
-          36.07523
+          -76.460199,
+          34.797385
         ],
         "type": "Point"
       },
@@ -5570,23 +5570,23 @@
     },
     {
       "properties": {
-        "government": "Orange",
-        "publicbody": "Hillsborough Planning Board",
-        "location": "Hillsborough Town Hall Annex",
-        "address": "Hillsborough, North Carolina, United States",
-        "schedule": "7:00 pm Third Thursday of each month",
+        "government": "Orange County",
+        "publicbody": "Orange County Planning Board (REQUIRES DISCLOSURE STATEMENT)",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "7:00 pm First Wednesday of every month",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=42",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=56",
         "id": 332
       },
       "geometry": {
-        "longitude": -79.099228,
-        "latitude": 36.07523,
+        "longitude": -78.522231,
+        "latitude": 35.129611,
         "coordinates": [
-          -79.099228,
-          36.07523
+          -78.522231,
+          35.129611
         ],
         "type": "Point"
       },
@@ -5594,23 +5594,23 @@
     },
     {
       "properties": {
-        "government": "Orange",
-        "publicbody": "Historic Preservation Commission (APPLICANTS SHALL RESIDE WITHIN THE TERRITORIAL JURISDICTION OF ORANGE COUNTY)",
-        "location": "Old Orange County Courthouse",
-        "address": "Orange County Courthouse, 106 E Margaret Ln, Hillsborough, North Carolina 27278, United States",
-        "schedule": "7:00 pm Fourth Wednesday of every month",
+        "government": "Orange County",
+        "publicbody": "Orange Unified Transportation Board",
+        "location": "West Campus Office Building, Room 204",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:30 pm Third Wednesday of every month",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=53",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144670",
         "id": 333
       },
       "geometry": {
-        "longitude": -79.099206,
-        "latitude": 36.0745765,
+        "longitude": -78.522231,
+        "latitude": 35.129611,
         "coordinates": [
-          -79.099206,
-          36.0745765
+          -78.522231,
+          35.129611
         ],
         "type": "Point"
       },
@@ -5618,15 +5618,15 @@
     },
     {
       "properties": {
-        "government": "Orange",
-        "publicbody": "Human Relations Commission",
-        "location": "TBD",
+        "government": "Orange County",
+        "publicbody": "Orange Water \u0026 Sewer Authority Board of Directors",
+        "location": "OWASA Community Room",
         "address": "Orange, North Carolina, United States",
-        "schedule": "6:00 pm Fourth Tuesday of every month",
+        "schedule": "6:00 pm Second Thursday of every month",
         "start": "",
         "end": "",
         "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=16",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=21",
         "id": 334
       },
       "geometry": {
@@ -5642,247 +5642,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
-        "publicbody": "Jury Commission",
-        "location": "Orange County Courthouse",
-        "address": "Orange County Courthouse, 106 E Margaret Ln, Hillsborough, North Carolina 27278, United States",
-        "schedule": "As needed As needed",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=10",
-        "id": 335
-      },
-      "geometry": {
-        "longitude": -79.099206,
-        "latitude": 36.0745765,
-        "coordinates": [
-          -79.099206,
-          36.0745765
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Mebane Board of Adjustment",
-        "location": "Mebane Town Hall",
-        "address": "Mebane, North Carolina, United States",
-        "schedule": "6:00 pm First Monday of every month (if necessary)",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=26",
-        "id": 336
-      },
-      "geometry": {
-        "longitude": -79.266962,
-        "latitude": 36.095972,
-        "coordinates": [
-          -79.266962,
-          36.095972
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Mebane Planning Board",
-        "location": "Mebane Town Hall",
-        "address": "Mebane, North Carolina, United States",
-        "schedule": "6:30 pm Second Monday of every month (if necessary)",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=32",
-        "id": 337
-      },
-      "geometry": {
-        "longitude": -79.266962,
-        "latitude": 36.095972,
-        "coordinates": [
-          -79.266962,
-          36.095972
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Nursing Home Community Advisory Committee",
-        "location": "Seymour Center, 2551 Homestead Rd., Chapel Hill",
-        "address": "Chapel Hill, North Carolina, United States",
-        "schedule": "5:30 pm First Tuesday of every other month",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=4",
-        "id": 338
-      },
-      "geometry": {
-        "longitude": -79.05578,
-        "latitude": 35.913154,
-        "coordinates": [
-          -79.05578,
-          35.913154
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Orange County Board of Adjustment (REQUIRES DISCLOSURE STATEMENT)",
-        "location": "Whitted Building, Room 230",
-        "address": "Orange Street, Beaufort, North Carolina 28516, United States",
-        "schedule": "7:00 pm Second Monday of every month",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=46",
-        "id": 339
-      },
-      "geometry": {
-        "longitude": -76.66512,
-        "latitude": 34.72012,
-        "coordinates": [
-          -76.66512,
-          34.72012
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Orange County Housing Authority",
-        "location": "Southern Human Services Center",
-        "address": "Orange, North Carolina, United States",
-        "schedule": "6:00 pm Third Wednesday of every month",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144698",
-        "id": 340
-      },
-      "geometry": {
-        "longitude": -78.522231,
-        "latitude": 35.129611,
-        "coordinates": [
-          -78.522231,
-          35.129611
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Orange County Parks and Recreation Council",
-        "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
-        "address": "Davis, North Carolina, United States",
-        "schedule": "6:30 pm First Wednesday of every month",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=44",
-        "id": 341
-      },
-      "geometry": {
-        "longitude": -76.460199,
-        "latitude": 34.797385,
-        "coordinates": [
-          -76.460199,
-          34.797385
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Orange County Planning Board (REQUIRES DISCLOSURE STATEMENT)",
-        "location": "TBD",
-        "address": "Orange, North Carolina, United States",
-        "schedule": "7:00 pm First Wednesday of every month",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=56",
-        "id": 342
-      },
-      "geometry": {
-        "longitude": -78.522231,
-        "latitude": 35.129611,
-        "coordinates": [
-          -78.522231,
-          35.129611
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Orange Unified Transportation Board",
-        "location": "West Campus Office Building, Room 204",
-        "address": "Orange, North Carolina, United States",
-        "schedule": "6:30 pm Third Wednesday of every month",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144670",
-        "id": 343
-      },
-      "geometry": {
-        "longitude": -78.522231,
-        "latitude": 35.129611,
-        "coordinates": [
-          -78.522231,
-          35.129611
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
-        "publicbody": "Orange Water \u0026 Sewer Authority Board of Directors",
-        "location": "OWASA Community Room",
-        "address": "Orange, North Carolina, United States",
-        "schedule": "6:00 pm Second Thursday of every month",
-        "start": "",
-        "end": "",
-        "remote": "",
-        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=21",
-        "id": 344
-      },
-      "geometry": {
-        "longitude": -78.522231,
-        "latitude": 35.129611,
-        "coordinates": [
-          -78.522231,
-          35.129611
-        ],
-        "type": "Point"
-      },
-      "type": "Feature"
-    },
-    {
-      "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "GoTriangle Special Tax Board (COMMISSIONERS ONLY)",
         "location": "TBD",
         "address": "Orange, North Carolina, United States",
@@ -5891,7 +5651,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144708",
-        "id": 345
+        "id": 335
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5906,7 +5666,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Joint Orange Chatham Community Action Agency (CURRENTLY NOT ACCEPTING APPLICATIONS)",
         "location": "alternating locations-Orange/Chatham",
         "address": "Orange, North Carolina, United States",
@@ -5915,7 +5675,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=43",
-        "id": 346
+        "id": 336
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5930,7 +5690,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Orange County Climate Council",
         "location": "TBA",
         "address": "Orange, North Carolina, United States",
@@ -5939,7 +5699,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144716",
-        "id": 347
+        "id": 337
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5954,7 +5714,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Solid Waste Advisory Group (SWAG)",
         "location": "",
         "address": "Orange, North Carolina, United States",
@@ -5963,7 +5723,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144710",
-        "id": 348
+        "id": 338
       },
       "geometry": {
         "longitude": -78.522231,
@@ -5978,7 +5738,7 @@
     },
     {
       "properties": {
-        "government": "Orange",
+        "government": "Orange County",
         "publicbody": "Workforce Development Board - Regional Partnership",
         "location": "Rotates between participating counties",
         "address": "Orange, North Carolina, United States",
@@ -5987,7 +5747,7 @@
         "end": "",
         "remote": "",
         "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=29",
-        "id": 349
+        "id": 339
       },
       "geometry": {
         "longitude": -78.522231,

--- a/meetings.json
+++ b/meetings.json
@@ -2,23 +2,3887 @@
   "features": [
     {
       "properties": {
+        "government": "City of Asheville",
+        "publicbody": "City Council",
+        "location": "Harrah\u2019s Cherokee Center",
+        "address": "87 Haywood St, Asheville, NC 28801",
+        "schedule": "2nd and 4th Tuesday of every month",
+        "start": "5:00 PM",
+        "end": "",
+        "remote": "Meetings are live-streamed on the City\u2019s YouTube Channel https://www.youtube.com/user/CityofAsheville and our Virtual Engagement Hub https://publicinput.com/hub/88 . Meeting are also streamed to Spectrum Cable Channel 193.",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 100
+      },
+      "geometry": {
+        "longitude": -82.554016,
+        "latitude": 35.60095,
+        "coordinates": [
+          -82.554016,
+          35.60095
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Buncombe County",
+        "publicbody": "Affordable Housing Committee",
+        "location": "Buncombe County Permits \u0026 Inspections",
+        "address": "30 Valley Street, Meeting Room, Asheville, NC 28801",
+        "schedule": "1st Tuesday of each month",
+        "start": "1:00 PM",
+        "end": "2:30 PM",
+        "remote": "",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 101
+      },
+      "geometry": {
+        "longitude": -82.53,
+        "latitude": 35.61,
+        "coordinates": [
+          -82.53,
+          35.61
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Asheville-Buncombe County",
+        "publicbody": "AB Tech/Buncombe County Joint Capital Advisory Committee",
+        "location": "County Administration Building",
+        "address": "200 College Street",
+        "schedule": "As needed",
+        "start": "",
+        "end": "",
+        "remote": "Zoom",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 102
+      },
+      "geometry": {
+        "longitude": -82.559814,
+        "latitude": 35.596121,
+        "coordinates": [
+          -82.559814,
+          35.596121
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Buncombe County",
+        "publicbody": "Ad Hoc Reappraisal Committee",
+        "location": "County Administration Building",
+        "address": "200 College Street, 1st Floor Conference Room Asheville, NC 28801",
+        "schedule": "1st and 3rd Wednesday of every month",
+        "start": "5:00 PM",
+        "end": "7:00 PM",
+        "remote": "855-925-2801 Meeting code: 9236 \r\nEmail UX8750@PublicInput.com",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 103
+      },
+      "geometry": {
+        "longitude": -82.559814,
+        "latitude": 35.596121,
+        "coordinates": [
+          -82.559814,
+          35.596121
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Buncombe County",
+        "publicbody": "Adult Care Home Community Advisory Committee",
+        "location": "Land of Sky Regional Council Offices",
+        "address": "339 New Leicester Highway Asheville 28806",
+        "schedule": "3rd Friday of each month",
+        "start": "9:00 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 104
+      },
+      "geometry": {
+        "longitude": -82.621802,
+        "latitude": 35.60139,
+        "coordinates": [
+          -82.621802,
+          35.60139
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Asheville-Buncombe County",
+        "publicbody": "African American Heritage Commission",
+        "location": "City Hall",
+        "address": "70 Court Plaza, 1st Floor North Conference Room Asheville, NC 28801 ",
+        "schedule": "2nd Thursday of each month",
+        "start": "11:30 AM",
+        "end": "",
+        "remote": "Watch live through the Engagement Hub: Public Engagement Hub or watch live on the City YouTube Channel.\n\nListen live by calling 855-925-2801 Enter Code 9409.\n\nPre-recorded voicemail comments by calling 855-925-2801 Enter Code 9409.  Voicemail comments will be accepted until Wednesday, April 13 at 5:00 PM\n\nWritten public comments by email \u2013 AAHCAVL@PublicInput.com.",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 105
+      },
+      "geometry": {
+        "longitude": -82.554016,
+        "latitude": 35.60095,
+        "coordinates": [
+          -82.554016,
+          35.60095
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Buncombe County",
+        "publicbody": "Agricultural Advisory Board for Farmland Preservation",
+        "location": "Soil \u0026 Water conference",
+        "address": "49 Mt. Carmel Road, Asheville, NC 28806",
+        "schedule": "3rd Tuesday of each month",
+        "start": "11:00 AM",
+        "end": "12:00 PM",
+        "remote": "Zoom",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 106
+      },
+      "geometry": {
+        "longitude": -82.569736,
+        "latitude": 35.689584,
+        "coordinates": [
+          -82.569736,
+          35.689584
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "City of Asheville",
+        "publicbody": "Asheville Board of Adjustment",
+        "location": "City Hall",
+        "address": "70 Court Plaza, 1st Floor North Conference Room Asheville, NC 28801 ",
+        "schedule": "4th Monday of each month",
+        "start": "2:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 107
+      },
+      "geometry": {
+        "longitude": -82.554016,
+        "latitude": 35.60095,
+        "coordinates": [
+          -82.554016,
+          35.60095
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Asheville-Buncombe County",
+        "publicbody": "Asheville-Buncombe Regional Sports Commission",
+        "location": "Chamber of Commerce",
+        "address": "36 Montford Ave, Asheville, NC 28801",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 108
+      },
+      "geometry": {
+        "longitude": -82.554016,
+        "latitude": 35.60095,
+        "coordinates": [
+          -82.554016,
+          35.60095
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Asheville-Buncombe County",
+        "publicbody": "Asheville Buncombe Technical CC Board of Trustees",
+        "location": "A-B Tech -- Magnolia Building",
+        "address": "340 Victoria Road, Asheville, NC 28801",
+        "schedule": "1st Monday of every month (except January \u0026 July)",
+        "start": "12 Noon in February, 3:30 PM for all others",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 109
+      },
+      "geometry": {
+        "longitude": -82.492382,
+        "latitude": 35.587814,
+        "coordinates": [
+          -82.492382,
+          35.587814
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "City of Asheville",
+        "publicbody": "Asheville Planning and Zoning Commission",
+        "location": "City Hall",
+        "address": "70 Court Plaza, 1st Floor North Conference Room Asheville, NC 28801 ",
+        "schedule": "1st Wednesday of each month",
+        "start": "5:00 PM",
+        "end": "",
+        "remote": "Phone: Voicemail comments may be pre-recorded by calling 855-925-2801 and entering code 9273 when prompted (available until 5:00 PM the day before the meeting).\nEmail: Written comments may be submitted to AVLPZC@PublicInput.com (available until 5:00 PM the day before the meeting).",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 110
+      },
+      "geometry": {
+        "longitude": -82.554016,
+        "latitude": 35.60095,
+        "coordinates": [
+          -82.554016,
+          35.60095
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "City of Asheville",
+        "publicbody": "Asheville Regional Housing Consortium",
+        "location": "Public Works Bldg",
+        "address": "161 S Charlotte Street, Room 109 Asheville 28801 ",
+        "schedule": "4th Wednesday",
+        "start": "9:30 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.buncombecounty.org/transparency/boards-commissions/default.aspx",
+        "id": 111
+      },
+      "geometry": {
+        "longitude": -82.548778,
+        "latitude": 35.592968,
+        "coordinates": [
+          -82.548778,
+          35.592968
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "",
+        "publicbody": "",
+        "location": "",
+        "address": "",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 112
+      },
+      "geometry": {
+        "longitude": -79.3896838690365,
+        "latitude": 35.5568849207,
+        "coordinates": [
+          -79.3896838690365,
+          35.5568849207
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "",
+        "publicbody": "",
+        "location": "",
+        "address": "",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 113
+      },
+      "geometry": {
+        "longitude": -79.3896838690365,
+        "latitude": 35.5568849207,
+        "coordinates": [
+          -79.3896838690365,
+          35.5568849207
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "County Commissioners",
+        "location": "County Office Building",
+        "address": "124 W. Elm St., Commissioners Meeting Room located on the 2nd Floor, Graham, NC  27253",
+        "schedule": "1st Monday and 3rd Monday of the month",
+        "start": "9:00 AM and 7:00 PM, respectively",
+        "end": "",
+        "remote": "Video recordings of our Commissioners Meetings both online and on the local Time-Warner Public Access Channels.  The television broadcast of the meetings will occur on the 2nd and 4th Wednesdays of each month at 10 PM.  Online videos will be made available after processing the videos through Youtube, our service providers for multimedia.  The meetings are now streamed live.",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/",
+        "id": 114
+      },
+      "geometry": {
+        "longitude": -79.814381,
+        "latitude": 35.7112915,
+        "coordinates": [
+          -79.814381,
+          35.7112915
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Adult Care Home Community Advisory Committee",
+        "location": "J. R. Kernodle Senior Center",
+        "address": "1535 S Mebane St\nBurlington NC 27215",
+        "schedule": "3rd Tuesday of each quarter",
+        "start": "2:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/adult-care-home-community-advisory-committee/",
+        "id": 115
+      },
+      "geometry": {
+        "longitude": -79.451938,
+        "latitude": 36.080331,
+        "coordinates": [
+          -79.451938,
+          36.080331
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Agricultural Advisory Board",
+        "location": "Agricultural Building Auditorium",
+        "address": "",
+        "schedule": "1st Wednesday of each quarter",
+        "start": "12:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/agricultural-advisory-board/",
+        "id": 116
+      },
+      "geometry": {
+        "longitude": -79.487215,
+        "latitude": 36.077676,
+        "coordinates": [
+          -79.487215,
+          36.077676
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Alamance Beautiful Commission",
+        "location": "Agricultural Extension Center",
+        "address": "",
+        "schedule": "Every 4th Tuesday except July \u0026 December",
+        "start": "12:15 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/alamance-beautiful-commission/",
+        "id": 117
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Alamance Community College Board of Trustees",
+        "location": "Alamance Community College, Wallace Gee Bldg.",
+        "address": "1247 Jimmie Kerr Rd\nGraham, NC 27253",
+        "schedule": "2nd Monday of every month except July and December",
+        "start": "6:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/alamance-community-college-board-of-trustees/",
+        "id": 118
+      },
+      "geometry": {
+        "longitude": -79.35742400000001,
+        "latitude": 36.0652275,
+        "coordinates": [
+          -79.35742400000001,
+          36.0652275
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Alamance County Board of Adjustment",
+        "location": "Commissioners\u2019 Room",
+        "address": "",
+        "schedule": "1st Monday of the month, when required",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/alamance-county-board-of-adjustment/",
+        "id": 119
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Alamance County Planning Board",
+        "location": "",
+        "address": "124 W Elm Street\nGraham, NC 27253",
+        "schedule": "2nd Thursday of each month",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "https://www.youtube.com/channel/UC1QADkhkyUpac9rMs42imjA",
+        "moreInfo": "https://www.alamance-nc.com/planningdept/boards/planning-board/",
+        "id": 120
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Alamance County Senior Services Committee",
+        "location": "J. R. Kernodle Senior Center",
+        "address": "1535 S Mebane St\nBurlington NC 27215",
+        "schedule": "2nd Tuesday of each month",
+        "start": "8:30 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/senior-services-committee/",
+        "id": 121
+      },
+      "geometry": {
+        "longitude": -79.451938,
+        "latitude": 36.080331,
+        "coordinates": [
+          -79.451938,
+          36.080331
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Alamance County Transportation Authority",
+        "location": "ACTA Office",
+        "address": "",
+        "schedule": "3rd Wednesday of each month",
+        "start": "4:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/alamance-county-transportation-authority/",
+        "id": 122
+      },
+      "geometry": {
+        "longitude": -79.814381,
+        "latitude": 35.7112915,
+        "coordinates": [
+          -79.814381,
+          35.7112915
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Altamahaw Ossipee Fire District Commission",
+        "location": "Altamahaw Ossipee Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/altamahaw-ossipee-fire-district-commission/",
+        "id": 123
+      },
+      "geometry": {
+        "longitude": -79.507246,
+        "latitude": 36.184302,
+        "coordinates": [
+          -79.507246,
+          36.184302
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Animal Review Board",
+        "location": "",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/animal-review-board/",
+        "id": 124
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Board of Equalization and Review",
+        "location": "Commissioners\u2019 Meeting Room",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/board-of-equalization-and-review/",
+        "id": 125
+      },
+      "geometry": {
+        "longitude": -79.790701,
+        "latitude": 36.076168,
+        "coordinates": [
+          -79.790701,
+          36.076168
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Board of Health",
+        "location": "Professional Boardroom",
+        "address": "",
+        "schedule": "3rd Tuesday of each month",
+        "start": "6:30 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/healthdept/board-of-health/",
+        "id": 126
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Burlington Board of Adjustment",
+        "location": "Burlington City Council Chambers",
+        "address": "",
+        "schedule": "2nd Tuesday of each month",
+        "start": "8:30 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/burlington-board-of-adjustment/",
+        "id": 127
+      },
+      "geometry": {
+        "longitude": -79.437799,
+        "latitude": 36.095692,
+        "coordinates": [
+          -79.437799,
+          36.095692
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Burlington Planning and Zoning Commission",
+        "location": "Burlington Municipal Building, Room 202",
+        "address": "",
+        "schedule": "4th Monday of each month",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/burlington-planning-and-zoning-commission/",
+        "id": 128
+      },
+      "geometry": {
+        "longitude": -79.436653,
+        "latitude": 36.091335,
+        "coordinates": [
+          -79.436653,
+          36.091335
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Burlington-Alamance Airport Authority",
+        "location": "Airport Terminal Building",
+        "address": "",
+        "schedule": "3rd Wednesday of each month",
+        "start": "12:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/burlington-alamance-airport-authority/",
+        "id": 129
+      },
+      "geometry": {
+        "longitude": -79.476222,
+        "latitude": 36.048977,
+        "coordinates": [
+          -79.476222,
+          36.048977
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "E. M. Holt Fire District Commission",
+        "location": "E. M. Holt Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/e-m-holt-fire-district-commission/",
+        "id": 130
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "EMS Peer Review Committee",
+        "location": "EMS Center",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/ems-peer-review-committee/",
+        "id": 131
+      },
+      "geometry": {
+        "longitude": -79.355225,
+        "latitude": 36.11158,
+        "coordinates": [
+          -79.355225,
+          36.11158
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Eli Whitney Fire District Commission",
+        "location": "Eli Whitney Fire Department",
+        "address": "",
+        "schedule": "Monthly",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/eli-whitney-fire-district-commission/",
+        "id": 132
+      },
+      "geometry": {
+        "longitude": -79.307239,
+        "latitude": 35.906807,
+        "coordinates": [
+          -79.307239,
+          35.906807
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Elon Fire District Commission",
+        "location": "Elon Fire Department",
+        "address": "",
+        "schedule": "Bi-monthly",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/elon-fire-district-commission/",
+        "id": 133
+      },
+      "geometry": {
+        "longitude": -79.50669,
+        "latitude": 36.102913,
+        "coordinates": [
+          -79.50669,
+          36.102913
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Elon Planning and Zoning Commission",
+        "location": "Elon Town Hall",
+        "address": "",
+        "schedule": "Third Tuesday of each month",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/elon-planning-and-zoning-commission/",
+        "id": 134
+      },
+      "geometry": {
+        "longitude": -79.50669,
+        "latitude": 36.102913,
+        "coordinates": [
+          -79.50669,
+          36.102913
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Faucette Fire District Commission",
+        "location": "Faucette Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/faucette-fire-district-commission/",
+        "id": 135
+      },
+      "geometry": {
+        "longitude": -79.520187,
+        "latitude": 36.066268,
+        "coordinates": [
+          -79.520187,
+          36.066268
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Gibsonville Board of Adjustment",
+        "location": "Gibsonville Town Hall",
+        "address": "",
+        "schedule": "As called",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/gibsonville-board-of-adjustment/",
+        "id": 136
+      },
+      "geometry": {
+        "longitude": -79.543097,
+        "latitude": 36.106198,
+        "coordinates": [
+          -79.543097,
+          36.106198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Gibsonville Planning Board",
+        "location": "Gibsonville Town Hall",
+        "address": "",
+        "schedule": "3rd Thursday of each month",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/gibsonville-planning-board/",
+        "id": 137
+      },
+      "geometry": {
+        "longitude": -79.543097,
+        "latitude": 36.106198,
+        "coordinates": [
+          -79.543097,
+          36.106198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Graham Board of Adjustment",
+        "location": "",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/graham-board-of-adjustment/",
+        "id": 138
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Graham Planning Board",
+        "location": "Council Chambers of Graham Municipal Building",
+        "address": "",
+        "schedule": "Third Tuesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/graham-planning-board/",
+        "id": 139
+      },
+      "geometry": {
+        "longitude": -79.400576,
+        "latitude": 36.069026,
+        "coordinates": [
+          -79.400576,
+          36.069026
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Haw River Fire District Commission",
+        "location": "Haw River Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/haw-river-fire-district-commission/",
+        "id": 140
+      },
+      "geometry": {
+        "longitude": -79.364186,
+        "latitude": 36.091526,
+        "coordinates": [
+          -79.364186,
+          36.091526
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Haw River Planning and Zoning Commission",
+        "location": "Haw River Municipal Building",
+        "address": "",
+        "schedule": "1st Tuesday of each month",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/haw-river-planning-and-zoning-commission/",
+        "id": 141
+      },
+      "geometry": {
+        "longitude": -79.364186,
+        "latitude": 36.091526,
+        "coordinates": [
+          -79.364186,
+          36.091526
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Historic Properties Commission",
+        "location": "",
+        "address": "",
+        "schedule": "2nd Tuesday of each month",
+        "start": "6:00 PM",
+        "end": "",
+        "remote": "https://www.youtube.com/channel/UCdav77c1nQtsM1tnx5rr0yQ",
+        "moreInfo": "https://www.alamance-nc.com/planningdept/boards/historic-properties-commission/",
+        "id": 142
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Jury Commission",
+        "location": "",
+        "address": "",
+        "schedule": "September and October as needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/jury-commission/",
+        "id": 143
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Justice Advisory Council",
+        "location": "Family Justice Center Training Room",
+        "address": "1951 Martin Street\nBurlington, NC 27217",
+        "schedule": "1st Tuesday of each month",
+        "start": "8:00 AM",
+        "end": "9:30 AM",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/justice-advisory-council/",
+        "id": 144
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Juvenile Crime Prevention Council",
+        "location": "Graham Civic Center",
+        "address": "500 McGee St\nGraham, NC 27253",
+        "schedule": "3rd Tuesday of each quarter",
+        "start": "12:30 PM",
+        "end": "2:00 PM",
+        "remote": "Please contact Karen Collins, JCPC Administrative Assistant, kcjcpc@outlook.comfor virtual meeting links.",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/juvenile-crime-prevention-council/",
+        "id": 145
+      },
+      "geometry": {
+        "longitude": -79.400576,
+        "latitude": 36.069026,
+        "coordinates": [
+          -79.400576,
+          36.069026
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Library Committee",
+        "location": "One of the four libraries",
+        "address": "",
+        "schedule": "Four times per year",
+        "start": "Alternates between 12:30 PM and 6:30pm",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/library-committee/",
+        "id": 146
+      },
+      "geometry": {
+        "longitude": -78.888448,
+        "latitude": 35.9023,
+        "coordinates": [
+          -78.888448,
+          35.9023
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Local Emergency Planning Committee (LEPC) for Hazardous Chemicals",
+        "location": "Family Justice Center",
+        "address": "1950 Martin St\nBurlington, NC",
+        "schedule": "Quarterly",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/local-emergency-planning-committee-lepc-for-hazardous-chemicals/",
+        "id": 147
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Mebane Board of Adjustment",
+        "location": "Mebane Municipal Building, City Council Chambers",
+        "address": "",
+        "schedule": "1st Monday of each month",
+        "start": "6:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/mebane-board-of-adjustment/",
+        "id": 148
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Mebane Fire Department",
+        "location": "Mebane Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/mebane-fire-department/",
+        "id": 149
+      },
+      "geometry": {
+        "longitude": -79.291313,
+        "latitude": 36.075886,
+        "coordinates": [
+          -79.291313,
+          36.075886
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Mebane Planning Board",
+        "location": "Mebane Municipal Building, City Council Chambers",
+        "address": "",
+        "schedule": "2nd Monday of each month",
+        "start": "6:30 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/mebane-planning-board/",
+        "id": 150
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "North Central Fire District Commission",
+        "location": "North Central Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/north-central-fire-district-commission/",
+        "id": 151
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "North Eastern Fire District Commission",
+        "location": "North Eastern Fire Department",
+        "address": "",
+        "schedule": "Monthly",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/north-eastern-fire-district-commission/",
+        "id": 152
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Nursing Home Community Advisory Committee",
+        "location": "J.R. Kernodle Senior Center",
+        "address": "1535 S Mebane St\nBurlington NC 27215",
+        "schedule": "1st Thursday of each quarter",
+        "start": "9:30 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/nursing-home-community-advisory-committee/",
+        "id": 153
+      },
+      "geometry": {
+        "longitude": -79.451938,
+        "latitude": 36.080331,
+        "coordinates": [
+          -79.451938,
+          36.080331
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Public Transit Advisory Commission (PTAC)",
+        "location": "",
+        "address": "",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/public-transit-advisory-commission-ptac/",
+        "id": 154
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Recreation and Parks Commission",
+        "location": "Varies",
+        "address": "Varies",
+        "schedule": "3rd Tuesday of each quarter",
+        "start": "12:30 PM or 6:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/recreation/home/recreation-and-parks-commission/",
+        "id": 155
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Snow Camp Fire Department",
+        "location": "Snow Camp Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/snow-camp-fire-department/",
+        "id": 156
+      },
+      "geometry": {
+        "longitude": -79.43002,
+        "latitude": 35.893472,
+        "coordinates": [
+          -79.43002,
+          35.893472
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Social Services Board",
+        "location": "Human Services Professional Board Room",
+        "address": "",
+        "schedule": "4th Tuesday of each month",
+        "start": "12:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/dss/social-services-board/",
+        "id": 157
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Swepsonville Fire District Commission",
+        "location": "Swepsonville Fire Department",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/swepsonville-fire-district-commission/",
+        "id": 158
+      },
+      "geometry": {
+        "longitude": -79.520187,
+        "latitude": 36.066268,
+        "coordinates": [
+          -79.520187,
+          36.066268
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Tourism Development Authority",
+        "location": "Chamber of Commerce/Visitor Bureau",
+        "address": "",
+        "schedule": "4th Tuesday of every other month, beginning January",
+        "start": "8:30 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/tourism-development-authority/",
+        "id": 159
+      },
+      "geometry": {
+        "longitude": -78.902268,
+        "latitude": 35.99853,
+        "coordinates": [
+          -78.902268,
+          35.99853
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Veterans Service Committee",
+        "location": "Veterans Service Office",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/veterans-service-committee/",
+        "id": 160
+      },
+      "geometry": {
+        "longitude": -79.4,
+        "latitude": 36.04,
+        "coordinates": [
+          -79.4,
+          36.04
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Village of Alamance Planning Board",
+        "location": "Village of Alamance Town Hall",
+        "address": "",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/village-of-alamance-planning-board/",
+        "id": 161
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance County",
+        "publicbody": "Workforce Development Board",
+        "location": "Rotate at Alamance, Orange, or Randolph County",
+        "address": "",
+        "schedule": "3rd Thursday of the first month in each quarter",
+        "start": "11:00 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/workforce-development-board/",
+        "id": 162
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "",
+        "publicbody": "",
+        "location": "",
+        "address": "",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 163
+      },
+      "geometry": {
+        "longitude": -79.3896838690365,
+        "latitude": 35.5568849207,
+        "coordinates": [
+          -79.3896838690365,
+          35.5568849207
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Board of Commisioners",
+        "location": "Cumberland County Courthouse",
+        "address": "117 Dick Street, Room 118\nFayetteville, NC",
+        "schedule": "",
+        "start": "Every other Monday",
+        "end": "Varies, usually 09:00 AM or 06:45 PM",
+        "remote": "Site states \u0022The meetings are broadcast live on CCNCTV Spectrum Cable Channel 5. The meetings are rebroadcast the Wednesday following the meeting at 7:00 p.m. and Friday following the meeting at 10:30 a.m.\u0022  Recordings are available on Youtube here: https://www.youtube.com/user/CumberlandCountyNC/videos",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/meetings",
+        "id": 164
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "A.B.C. Board",
+        "location": "ABC Board Office Conference Room",
+        "address": "424 Person Street\nFayetteville, NC",
+        "schedule": "2nd Monday of each month",
+        "start": "6:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 165
+      },
+      "geometry": {
+        "longitude": -78.798912,
+        "latitude": 35.116553,
+        "coordinates": [
+          -78.798912,
+          35.116553
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Adult Care Home Community Advisory Committee",
+        "location": "Various adult care homes in Cumberland County",
+        "address": "Various adult care homes in Cumberland County",
+        "schedule": "3rd Thursday of the last month of each quarter",
+        "start": "1:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 166
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Animal Services Board",
+        "location": "Animal Services Department",
+        "address": "Animal Services Department \n4704 Corporation Drive \nFayetteville, NC",
+        "schedule": "First Monday of every other month (Feb/Apr/June/Aug/Oct/Dec). No meetings held on first or last day of any month.",
+        "start": "6:00 PM",
+        "end": "Varies",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 167
+      },
+      "geometry": {
+        "longitude": -78.974686,
+        "latitude": 35.05471,
+        "coordinates": [
+          -78.974686,
+          35.05471
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Board of Adjustment",
+        "location": "Historic Cumberland County Courthouse",
+        "address": "Hearing Room #3 \n130 Gillespie Street \nFayetteville, NC",
+        "schedule": "3rd Thursday of each month",
+        "start": "6:00 PM",
+        "end": "Varies",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 168
+      },
+      "geometry": {
+        "longitude": -78.885238,
+        "latitude": 35.057381,
+        "coordinates": [
+          -78.885238,
+          35.057381
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Board of Health",
+        "location": "Cumberland County Health Department",
+        "address": "Board Room \n1235 Ramsey Street \nFayetteville, NC",
+        "schedule": "3rd Tuesday of each month. July and September meetings take place only if desired.",
+        "start": "6:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 169
+      },
+      "geometry": {
+        "longitude": -78.889539,
+        "latitude": 35.053678,
+        "coordinates": [
+          -78.889539,
+          35.053678
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cape Fear Valley Health System Board of Trustees",
+        "location": "Cape Fear Valley Health System",
+        "address": "Board Room First Floor/Administrative Area \n1638 Owen Drive\nFayetteville, NC",
+        "schedule": "Last Wednesday of each month except April and July; November \u0026 December meetings are combined",
+        "start": "5:30 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 170
+      },
+      "geometry": {
+        "longitude": -78.814741,
+        "latitude": 35.42516,
+        "coordinates": [
+          -78.814741,
+          35.42516
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Civic Center Commission",
+        "location": "Cumberland County Civic Center",
+        "address": "Crown Coliseum Board Room \n1960 Coliseum Drive \nFayetteville, NC",
+        "schedule": "4th Tuesday of each month",
+        "start": "5:30 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 171
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Cemetery Commission",
+        "location": "Varies",
+        "address": "Varies",
+        "schedule": "As needed.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 172
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Community Child Protection/Fatality Prevention Team",
+        "location": "Department of Social Services Building",
+        "address": "4th Floor, Room 440 \n1225 Ramsey Street\nFayetteville, NC",
+        "schedule": "3rd Thursday of each month",
+        "start": "3:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 173
+      },
+      "geometry": {
+        "longitude": -77.925838,
+        "latitude": 34.21787,
+        "coordinates": [
+          -77.925838,
+          34.21787
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Finance Corporation",
+        "location": "Cumberland County Courthouse",
+        "address": "Room 564 \n117 Dick Street \nFayetteville, NC",
+        "schedule": "As needed.",
+        "start": "12:00 PM, usually",
+        "end": "Varies",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 174
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Home and Community Care Block Grant Committee",
+        "location": "Varies",
+        "address": "Varies",
+        "schedule": "As needed.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 175
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Industrial Facilities and Pollution Control Financing Authority",
+        "location": "Cumberland County Courthouse",
+        "address": "Room 564 \n117 Dick Street \nFayetteville, NC",
+        "schedule": "As needed.",
+        "start": "12:00 PM, usually",
+        "end": "Varies",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 176
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Juvenile Crime Prevention Council",
+        "location": "Cumberland County CommuniCare",
+        "address": "Lower Level Conference Room \n109 Bradford Ave \nFayetteville, NC 28301",
+        "schedule": "2nd Wednesday of each month",
+        "start": "1:15 PM",
+        "end": "03:15 PM at the latest",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 177
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Local Emergency Planning Committee",
+        "location": "Varies",
+        "address": "Varies",
+        "schedule": "Last Thursday of the first month of each quarter",
+        "start": "10:00 AM",
+        "end": "11:00 AM",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 178
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Cumberland County Workforce Development Board",
+        "location": "FTCC General Classroom Building",
+        "address": "Room 114\n2817 Ft. Bragg Rd",
+        "schedule": "3rd Tuesday of every other month, starting January",
+        "start": "11:00 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 179
+      },
+      "geometry": {
+        "longitude": -78.890066,
+        "latitude": 35.052648,
+        "coordinates": [
+          -78.890066,
+          35.052648
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Equalization and Review Board",
+        "location": "Cumberland County Courthouse",
+        "address": "Room 564 \n117 Dick Street \nFayetteville, NC",
+        "schedule": "2nd Wednesday of every month (except July)",
+        "start": "3:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 180
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Farm Advisory Board",
+        "location": "Historic Cumberland County Courthouse",
+        "address": "Room 107C \n130 Gillespie Street \nFayetteville, NC",
+        "schedule": "2nd Tuesday of the first month of each quarter",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 181
+      },
+      "geometry": {
+        "longitude": -78.885238,
+        "latitude": 35.057381,
+        "coordinates": [
+          -78.885238,
+          35.057381
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Fayetteville Area Convention and Visitors Bureau Board of Directors",
+        "location": "Fayetteville Area Convention and Visitors Bureau",
+        "address": "Board Room\n245 Person Street\nFayetteville, NC",
+        "schedule": "4th Wednesday of the first month of each quarter",
+        "start": "12:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 182
+      },
+      "geometry": {
+        "longitude": -78.874542,
+        "latitude": 35.051411,
+        "coordinates": [
+          -78.874542,
+          35.051411
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Fayetteville Cumberland County Economic Development Corporation",
+        "location": "",
+        "address": "201 Hay Street\nR. B. Williams Building Ste 401A\nFayetteville, NC",
+        "schedule": "2nd Tuesday of each month",
+        "start": "8:00 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 183
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Fayetteville Technical Community College Board of Trustees",
+        "location": "Fayetteville Technical Community College",
+        "address": "Board Room Tony Rand Student Center \n2201 Hull Road \nFayetteville, NC",
+        "schedule": "3rd Monday of each month except July and December, plus as called.",
+        "start": "12:30 PM",
+        "end": "4:30 PM",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 184
+      },
+      "geometry": {
+        "longitude": -78.9267805,
+        "latitude": 35.069124,
+        "coordinates": [
+          -78.9267805,
+          35.069124
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Fayetteville-Cumberland Parks and Recreation Advisory Commission",
+        "location": "City of Fayetteville Parks \u0026 Recreation",
+        "address": "121 Lamon Street \nFayetteville, NC",
+        "schedule": "1st Tuesday of each month",
+        "start": "5:30 PM",
+        "end": "7:00 PM",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 185
+      },
+      "geometry": {
+        "longitude": -78.878292,
+        "latitude": 35.052576,
+        "coordinates": [
+          -78.878292,
+          35.052576
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Human Relations Commission",
+        "location": "Festival Park Plaza Training Room",
+        "address": "1st Floor\n225 Ray Ave\nFayetteville, NC 28301",
+        "schedule": "2nd Thursday of each month",
+        "start": "5:30 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 186
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Joint Appearance Commission",
+        "location": "Fayetteville City Hall",
+        "address": "E.E. Smith Conference Room",
+        "schedule": "2nd Monday of each month",
+        "start": "5:30 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 187
+      },
+      "geometry": {
+        "longitude": -78.883411,
+        "latitude": 35.053686,
+        "coordinates": [
+          -78.883411,
+          35.053686
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Joint Fort Bragg \u0026 Cumberland County Food Policy Council",
+        "location": "",
+        "address": "1235 Ramsey Street\nFayetteville, NC",
+        "schedule": "1st Wednesday of each month",
+        "start": "12:00 PM on even-numbered days\n05:00 PM on odd-numbered days",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 188
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Joint Planning Board",
+        "location": "Historic Cumberland County Courthouse",
+        "address": "Hearing Room #3 \n130 Gillespie Street \nFayetteville, North Carolina",
+        "schedule": "3rd Tuesday of each month",
+        "start": "6:00 PM",
+        "end": "Varies",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 189
+      },
+      "geometry": {
+        "longitude": -78.885238,
+        "latitude": 35.057381,
+        "coordinates": [
+          -78.885238,
+          35.057381
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Jury Commission",
+        "location": "Judge E. Maurice Braswell Courthouse",
+        "address": "117 Dick Street, 3rd floor\nFayetteville, NC",
+        "schedule": "As often as required to complete the jury list for the next year by the 30th day of November of each year.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 190
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Library Board of Trustees",
+        "location": "Various libraries throughout the County",
+        "address": "Various libraries throughout the County",
+        "schedule": "3rd Thursday of each month except December",
+        "start": "9:05 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 191
+      },
+      "geometry": {
+        "longitude": -78.987023,
+        "latitude": 35.148377,
+        "coordinates": [
+          -78.987023,
+          35.148377
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Mid-Carolina Aging Advisory Council",
+        "location": "Various locations in the three county region (Cumberland, Harnett and Sampson counties)",
+        "address": "Various locations in the three county region (Cumberland, Harnett and Sampson counties)",
+        "schedule": "1st Thursday of the last month of each quarter",
+        "start": "2:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 192
+      },
+      "geometry": {
+        "longitude": -70.258169,
+        "latitude": 43.796655,
+        "coordinates": [
+          -70.258169,
+          43.796655
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "North Carolina Southeast",
+        "location": "",
+        "address": "70 West Broad Street\nElizabethtown, NC",
+        "schedule": "Quarterly",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 193
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Nursing Home Advisory Board",
+        "location": "Various nursing homes in Cumberland County",
+        "address": "Various nursing homes in Cumberland County",
+        "schedule": "3rd Thursday of the last month of each quarter",
+        "start": "10:00 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 194
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Senior Citizens Advisory Commission",
+        "location": "FCPR Senior Center",
+        "address": "Large Program Room\n739 Blue Street\nFayetteville, NC",
+        "schedule": "2nd Tuesday of each month",
+        "start": "2:30 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 195
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Social Services Board",
+        "location": "Department of Social Services",
+        "address": "Board Room \n1225 Ramsey Street\nFayetteville, NC",
+        "schedule": "Last Wednesday of each month",
+        "start": "1:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 196
+      },
+      "geometry": {
+        "longitude": -77.925838,
+        "latitude": 34.21787,
+        "coordinates": [
+          -77.925838,
+          34.21787
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Southeastern Economic Development Commission",
+        "location": "",
+        "address": "707 West Broad Street, \nElizabethtown, NC",
+        "schedule": "Once a year, usually April",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 197
+      },
+      "geometry": {
+        "longitude": -78.83,
+        "latitude": 35.05,
+        "coordinates": [
+          -78.83,
+          35.05
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Cumberland County",
+        "publicbody": "Transportation Advisory Board",
+        "location": "Historic Cumberland County Courthouse",
+        "address": "Hearing Room #3\n130 Gillespie Street \nFayetteville, NC",
+        "schedule": "2nd Tuesday of the first month of each quarter",
+        "start": "10:00 AM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
+        "id": 198
+      },
+      "geometry": {
+        "longitude": -78.885238,
+        "latitude": 35.057381,
+        "coordinates": [
+          -78.885238,
+          35.057381
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "",
+        "publicbody": "",
+        "location": "",
+        "address": "",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 199
+      },
+      "geometry": {
+        "longitude": -79.3896838690365,
+        "latitude": 35.5568849207,
+        "coordinates": [
+          -79.3896838690365,
+          35.5568849207
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Davidson County",
+        "publicbody": "Board of Elections",
+        "location": "Board of Commissioners Meeting Room",
+        "address": "Davidson County Government Center 4th Floor\n913 Greensboro Street\nLexington, NC 27292",
+        "schedule": "A few times a month",
+        "start": "6:00 PM",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://votedavidsoncountync.com/home-page",
+        "id": 200
+      },
+      "geometry": {
+        "longitude": -80.21,
+        "latitude": 35.79,
+        "coordinates": [
+          -80.21,
+          35.79
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Davidson County",
+        "publicbody": "Board of Health",
+        "location": "Health Department",
+        "address": "915 Greensboro Street\nLexington, NC  27292",
+        "schedule": "1st Tuesday of every other month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.co.davidson.nc.us/467/Board-of-Health",
+        "id": 201
+      },
+      "geometry": {
+        "longitude": -80.059071,
+        "latitude": 35.919706,
+        "coordinates": [
+          -80.059071,
+          35.919706
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Davidson County",
+        "publicbody": "Social Services Board",
+        "location": "",
+        "address": "Davidson County Governmental Center - 1st Floor\n913 Greensboro Street\nLexington, NC  27292",
+        "schedule": "4th Tuesday each month except December",
+        "start": "4:15 PM",
+        "end": "6:00 PM",
+        "remote": "",
+        "moreInfo": "https://www.co.davidson.nc.us/690/Social-Services-Board-Information",
+        "id": 202
+      },
+      "geometry": {
+        "longitude": -80.21,
+        "latitude": 35.79,
+        "coordinates": [
+          -80.21,
+          35.79
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Davidson County",
+        "publicbody": "Soil \u0026 Water Convservation District Board",
+        "location": "",
+        "address": "",
+        "schedule": "2nd Thursday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 203
+      },
+      "geometry": {
+        "longitude": -80.21,
+        "latitude": 35.79,
+        "coordinates": [
+          -80.21,
+          35.79
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "",
+        "publicbody": "",
+        "location": "",
+        "address": "",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 204
+      },
+      "geometry": {
+        "longitude": -79.3896838690365,
+        "latitude": 35.5568849207,
+        "coordinates": [
+          -79.3896838690365,
+          35.5568849207
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Adult Care Home Community Advisory Committee",
+        "location": "Piedmont Triad Regional Council",
+        "address": "1398 Carrollton Crossing Dr.\nKernersville, NC 27284",
+        "schedule": "1st Wednesday of Mar./June/Sep./Dec.",
+        "start": "1:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=2",
+        "id": 205
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Animal Services Advisory Board",
+        "location": "Forsyth County Animal Shelter",
+        "address": "5570 Sturmer Park Circle\nWinston-Salem, NC 27105",
+        "schedule": "3rd Thursday of each month",
+        "start": "6:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=75",
+        "id": 206
+      },
+      "geometry": {
+        "longitude": -80.280823,
+        "latitude": 36.171736,
+        "coordinates": [
+          -80.280823,
+          36.171736
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Appearance Commission, Winston-Salem/Forsyth County",
+        "location": "Bryce A. Stuart Municipal Building, City-County Planning Board Conference Room",
+        "address": "100 East First Street, Winston-Salem",
+        "schedule": "4th Wednesday of each month",
+        "start": "4:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=5",
+        "id": 207
+      },
+      "geometry": {
+        "longitude": -80.243258,
+        "latitude": 36.094755,
+        "coordinates": [
+          -80.243258,
+          36.094755
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Community Child Protection Team/Child Fatality Prevention Team",
+        "location": "Forsyth County Public Health Boardroom",
+        "address": "799 Highland Avenue\nWinston-Salem, NC",
+        "schedule": "4th Wednesday of each quarter",
+        "start": "8:15 AM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=43",
+        "id": 208
+      },
+      "geometry": {
+        "longitude": -80.232435,
+        "latitude": 36.103926,
+        "coordinates": [
+          -80.232435,
+          36.103926
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Environmental Assistance and Protection Board",
+        "location": "Equalization and Review Board Room",
+        "address": "Forsyth County Government Center, 1st Floor\n201 North Chestnut Street\nWinston-Salem, NC",
+        "schedule": "As called, typically once a quarter",
+        "start": "10:00 AM",
+        "end": "12:00 PM",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=13",
+        "id": 209
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Experiment in Self-Reliance",
+        "location": "",
+        "address": "1621 East Third Street",
+        "schedule": "1st Wednesday of September-June",
+        "start": "12:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=15",
+        "id": 210
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Forsyth County Health and Human Services Board",
+        "location": "Forsyth County Public Health Department",
+        "address": "799 North Highland Avenue",
+        "schedule": "1st Wednesday of each month",
+        "start": "5:30 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=87",
+        "id": 211
+      },
+      "geometry": {
+        "longitude": -80.0999,
+        "latitude": 36.109755,
+        "coordinates": [
+          -80.0999,
+          36.109755
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Forsyth County Historic Resources Commission",
+        "location": "5th Floor Public Meeting Room",
+        "address": "City Hall South\n100 East First Street, Winston-Salem",
+        "schedule": "1st Wednesday of each month",
+        "start": "4:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=44",
+        "id": 212
+      },
+      "geometry": {
+        "longitude": -80.2593,
+        "latitude": 36.064662,
+        "coordinates": [
+          -80.2593,
+          36.064662
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Library Board",
+        "location": "Central Library (may vary)",
+        "address": "",
+        "schedule": "2nd or 3rd Wednesday of Jan./Mar./May/Sep./Nov.",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=23",
+        "id": 213
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Nursing Home Community Advisory Committee, Forsyth County",
+        "location": "Polo Park Recreational Center",
+        "address": "1850 Polo Rd\nWinston-Salem, NC 27106",
+        "schedule": "3rd Monday of March, June, September, December",
+        "start": "6:30 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=26",
+        "id": 214
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Piedmont Triad Regional Workforce Development Board",
+        "location": "Piedmont Triad Regional Council",
+        "address": "1398 Carrollton Crossing Dr.\nKernersville, NC 27284",
+        "schedule": "3rd Wednesday of February, April, June, August, September, and October",
+        "start": "8:30 AM",
+        "end": "9:30 AM",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=86",
+        "id": 215
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Planning Board (City/County)",
+        "location": "Bryce A. Stuart Municipal Building, 5th floor public meeting room",
+        "address": "100 E. First Street, Winston-Salem",
+        "schedule": "2nd Thursday of each month",
+        "start": "4:30 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=29",
+        "id": 216
+      },
+      "geometry": {
+        "longitude": -80.243258,
+        "latitude": 36.094755,
+        "coordinates": [
+          -80.243258,
+          36.094755
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Planning Board, Kernersville",
+        "location": "Kernersville District Court Room",
+        "address": "",
+        "schedule": "2nd Monday of each month",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=30",
+        "id": 217
+      },
+      "geometry": {
+        "longitude": -80.073653,
+        "latitude": 36.119859,
+        "coordinates": [
+          -80.073653,
+          36.119859
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Public Art Commission (City/County)",
+        "location": "2nd Floor Conference Room of Bryce Stuart Building",
+        "address": "100 East First Street, Winston-Salem",
+        "schedule": "1st Tuesday of each month",
+        "start": "2:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=84",
+        "id": 218
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Smith Reynolds Airport Board",
+        "location": "Terminal Building at Smith Reynolds Airport",
+        "address": "3801 N. Liberty St, Winston-Salem, NC 27105",
+        "schedule": "3rd Tuesday of each month",
+        "start": "4:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=89",
+        "id": 219
+      },
+      "geometry": {
+        "longitude": -80.26,
+        "latitude": 36.13,
+        "coordinates": [
+          -80.26,
+          36.13
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Zoning Board of Adjustment, Forsyth County",
+        "location": "Bryce A. Stuart Municipal Building, 5th floor public meeting room",
+        "address": "100 E. First Street, Winston-Salem",
+        "schedule": "3rd Wednesday of each month",
+        "start": "2:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=39",
+        "id": 220
+      },
+      "geometry": {
+        "longitude": -80.243258,
+        "latitude": 36.094755,
+        "coordinates": [
+          -80.243258,
+          36.094755
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Zoning Board of Adjustment, Kernersville",
+        "location": "Kernersville District Court Room",
+        "address": "",
+        "schedule": "3rd Monday of each month",
+        "start": "7:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=40",
+        "id": 221
+      },
+      "geometry": {
+        "longitude": -80.073653,
+        "latitude": 36.119859,
+        "coordinates": [
+          -80.073653,
+          36.119859
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Forsyth County",
+        "publicbody": "Zoning Board of Adjustment, Winston-Salem",
+        "location": "Bryce A. Stuart Municipal Building, 5th floor public meeting room",
+        "address": "100 E. First Street, Winston-Salem",
+        "schedule": "1st Thursday of each month",
+        "start": "2:00 PM",
+        "end": "",
+        "remote": "Some Forsyth County meetings are streamed at https://vimeo.com/forsythcountync",
+        "moreInfo": "https://forsyth.cc/Commissioners/volunteer_boards.aspx?ItemID=41",
+        "id": 222
+      },
+      "geometry": {
+        "longitude": -80.243258,
+        "latitude": 36.094755,
+        "coordinates": [
+          -80.243258,
+          36.094755
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Adult Care Home Community Advisory Committee",
+        "location": "JR Kernodle Senior Center",
+        "address": "Kernodle Senior Center, 1535 S Mebane St, Burlington, North Carolina 27215, United States",
+        "schedule": "2:00 p.m. the third Tuesday of each quarter",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Tracy Warner, Ombudsman, (336) 904-0300",
+        "id": 223
+      },
+      "geometry": {
+        "longitude": -79.451938,
+        "latitude": 36.080331,
+        "coordinates": [
+          -79.451938,
+          36.080331
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Alamance County Senior Services Committee",
+        "location": "J. R. Kernodle Senior Center",
+        "address": "Kernodle Senior Center, 1535 S Mebane St, Burlington, North Carolina 27215, United States",
+        "schedule": "8:30 a.m. the second Tuesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Crystal Norman\u00A0 (336) 904-0300",
+        "id": 224
+      },
+      "geometry": {
+        "longitude": -79.451938,
+        "latitude": 36.080331,
+        "coordinates": [
+          -79.451938,
+          36.080331
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Board of Health",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/board-of-health/",
+        "id": 225
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Nursing Home Community Advisory Committee",
+        "location": "J.R. Kernodle Senior Center",
+        "address": "Kernodle Senior Center, 1535 S Mebane St, Burlington, North Carolina 27215, United States",
+        "schedule": "9:30 a.m. the first Thursday of each quarter",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Tracy Warner, Ombudsman, (336) 904-0300",
+        "id": 226
+      },
+      "geometry": {
+        "longitude": -79.451938,
+        "latitude": 36.080331,
+        "coordinates": [
+          -79.451938,
+          36.080331
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Social Services Board",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/human-services/social-services-board/",
+        "id": 227
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Workforce Development Board",
+        "location": "Rotate at Alamance, Orange, or Randolph County",
+        "address": "Randolph County, North Carolina, United States",
+        "schedule": "11:00 a.m. the 3rd Thursday in the 1st month of each quarter",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Tammy Wall 336-629-5141",
+        "id": 228
+      },
+      "geometry": {
+        "longitude": -79.81,
+        "latitude": 35.71,
+        "coordinates": [
+          -79.81,
+          35.71
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Animal Review Board",
+        "location": "",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Sheriff Terry Johnson\u00A0 336-570-6300",
+        "id": 229
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Jury Commission",
+        "location": "",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "September and October as needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Meredith Edwards, Clerk of Court 336-570-5200",
+        "id": 230
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Justice Advisory Council",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/justice-advisory-council/",
+        "id": 231
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Juvenile Crime Prevention Council",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/juvenile-crime-prevention-council/",
+        "id": 232
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "LEPC",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/public-safety/local-emergency-planning-committee-lepc-for-hazardous-chemicals/",
+        "id": 233
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Alamance County Board of Adjustment",
+        "location": "Commissioners\u2019 Room",
+        "address": "Country Inn \u0026 Suites by Radisson, 3211 Wilson Dr, Burlington, North Carolina 27215, United States",
+        "schedule": "7:00 p.m. the first Monday of the month when required",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Tonya Caddle 336-570-4052",
+        "id": 234
+      },
+      "geometry": {
+        "longitude": -79.502324,
+        "latitude": 36.068022,
+        "coordinates": [
+          -79.502324,
+          36.068022
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Alamance County Planning Board",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/alamance-county-planning-board/",
+        "id": 235
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Board of Equalization and Review",
+        "location": "Commissioners\u2019 Meeting Room",
+        "address": "Raleigh Marriott Crabtree Valley, 4500 Marriott Drive, Raleigh, North Carolina 27612, United States",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Jeremy Akins, Tax Administrator\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-228-1312",
+        "id": 236
+      },
+      "geometry": {
+        "longitude": -78.678044,
+        "latitude": 35.842902,
+        "coordinates": [
+          -78.678044,
+          35.842902
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Burlington Board of Adjustment",
+        "location": "Burlington City Council Chambers",
+        "address": "Burlington, North Carolina, United States",
+        "schedule": "8:30 a.m. the second Tuesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Conrad Olmedo 336-513-5416",
+        "id": 237
+      },
+      "geometry": {
+        "longitude": -79.437799,
+        "latitude": 36.095692,
+        "coordinates": [
+          -79.437799,
+          36.095692
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Burlington Planning and Zoning Commission",
+        "location": "Burlington Municipal Building, Room 202",
+        "address": "Burlington Municipal Building, 425 S Lexington Ave, Burlington, North Carolina 27215, United States",
+        "schedule": "7:00 p.m. the fourth Monday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Conrad Olmedo 336-513-5416",
+        "id": 238
+      },
+      "geometry": {
+        "longitude": -79.436653,
+        "latitude": 36.091335,
+        "coordinates": [
+          -79.436653,
+          36.091335
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Elon Planning and Zoning Commission",
+        "location": "Elon Town Hall",
+        "address": "Elon, North Carolina, United States",
+        "schedule": "7:00 p.m. the third Tuesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "DiAnne Enoch, Clerk\u00A0 336-584-3601",
+        "id": 239
+      },
+      "geometry": {
+        "longitude": -79.50669,
+        "latitude": 36.102913,
+        "coordinates": [
+          -79.50669,
+          36.102913
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Gibsonville Board of Adjustment",
+        "location": "Gibsonville Town Hall",
+        "address": "Gibsonville Town Hall, Gibsonville, North Carolina 27249, United States",
+        "schedule": "7:00 p.m. as called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Ben Baxley, Town Manager\u00A0\u00A0 336-449-4144",
+        "id": 240
+      },
+      "geometry": {
+        "longitude": -79.543097,
+        "latitude": 36.106198,
+        "coordinates": [
+          -79.543097,
+          36.106198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Gibsonville Planning Board",
+        "location": "Gibsonville Town Hall",
+        "address": "Gibsonville Town Hall, Gibsonville, North Carolina 27249, United States",
+        "schedule": "7:00 p.m. the third Thursday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Ben Baxley, Town Manager\u00A0\u00A0 336-449-4144",
+        "id": 241
+      },
+      "geometry": {
+        "longitude": -79.543097,
+        "latitude": 36.106198,
+        "coordinates": [
+          -79.543097,
+          36.106198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Graham Board of Adjustment",
+        "location": "",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Justin Snyder 336-570-6700",
+        "id": 242
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Graham Planning Board",
+        "location": "Council Chambers of Graham Municipal Building",
+        "address": "Graham, North Carolina, United States",
+        "schedule": "Third Tuesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Justin Snyder 336-570-6700",
+        "id": 243
+      },
+      "geometry": {
+        "longitude": -79.400576,
+        "latitude": 36.069026,
+        "coordinates": [
+          -79.400576,
+          36.069026
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Haw River Board of Adjustment",
+        "location": "Haw River Municipal Building",
+        "address": "Haw River, North Carolina, United States",
+        "schedule": "7:00 p.m. the first Tuesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Sean Tencer, Town Manager\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-578-0784",
+        "id": 244
+      },
+      "geometry": {
+        "longitude": -79.364186,
+        "latitude": 36.091526,
+        "coordinates": [
+          -79.364186,
+          36.091526
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Haw River Planning and Zoning Commission",
+        "location": "Haw River Municipal Building",
+        "address": "Haw River, North Carolina, United States",
+        "schedule": "7:00 p.m. the first Tuesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Sean Tencer, Town Manager\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-578-0784",
+        "id": 245
+      },
+      "geometry": {
+        "longitude": -79.364186,
+        "latitude": 36.091526,
+        "coordinates": [
+          -79.364186,
+          36.091526
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Historic Properties Commission",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/planning-and-taxation/historic-properties-commission/",
+        "id": 246
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Mebane Board of Adjustment",
+        "location": "Mebane Municipal Building, City Council Chambers",
+        "address": "Mebane, North Carolina, United States",
+        "schedule": "6:00 p.m. the first Monday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "919-563-9990",
+        "id": 247
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Mebane Planning Board",
+        "location": "Mebane Municipal Building, City Council Chambers",
+        "address": "Mebane, North Carolina, United States",
+        "schedule": "6:30 p.m. the second Monday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "919-563-9990",
+        "id": 248
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Village of Alamance Board of Adjustment",
+        "location": "Village of Alamance Town Hall",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Ben York, Clerk\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-226-0033",
+        "id": 249
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Village of Alamance Planning Board",
+        "location": "Village of Alamance Town Hall",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Ben York, Clerk\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-226-0033",
+        "id": 250
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Agricultural Advisory Board / Farmland Preservation",
+        "location": "Agricultural Building Auditorium",
+        "address": "La Cocina, 309 Huffman Mill Rd, Burlington, North Carolina 27215, United States",
+        "schedule": "12:00 p.m. the first Wednesday of each quarter",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Brad Moore\u00A0\u00A0\u00A0\u00A0 336-290-0380",
+        "id": 251
+      },
+      "geometry": {
+        "longitude": -79.487215,
+        "latitude": 36.077676,
+        "coordinates": [
+          -79.487215,
+          36.077676
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Alamance Beautiful Commission",
+        "location": "Agricultural Extension Center",
+        "address": "Center Road, Haw River, North Carolina 27258, United States",
+        "schedule": "12:15 p.m. the fourth Tuesday except July and December",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 252
+      },
+      "geometry": {
+        "longitude": -79.355225,
+        "latitude": 36.11158,
+        "coordinates": [
+          -79.355225,
+          36.11158
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Alamance Community College Board of Trustees",
+        "location": "Alamance Community College, Wallace Gee Bldg.",
+        "address": "Alamance Community College, 1247 Jimmie Kerr Rd, Graham, North Carolina 27253, United States",
+        "schedule": "6:00 p.m. the second Monday of the month except July \u0026 Dec.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Dr. Algie C. Gatewood, President\u00A0\u00A0 336-506-4150",
+        "id": 253
+      },
+      "geometry": {
+        "longitude": -79.35742400000001,
+        "latitude": 36.0652275,
+        "coordinates": [
+          -79.35742400000001,
+          36.0652275
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Alamance County Transportation Authority",
+        "location": "ACTA Office",
+        "address": "Lil Donnie Walkers Car Wash, 3804 S Mebane St, Burlington, North Carolina 27215, United States",
+        "schedule": "4:00 p.m. the third Wednesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Peter Murphy 336-222-0565",
+        "id": 254
+      },
+      "geometry": {
+        "longitude": -79.484225,
+        "latitude": 36.077891,
+        "coordinates": [
+          -79.484225,
+          36.077891
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Burlington-Alamance Airport Authority",
+        "location": "Airport Terminal Building",
+        "address": "Burlington-Alamance Regional Airport, 3441 N Aviation Dr, Burlington, North Carolina 27215, United States",
+        "schedule": "12:00 p.m. the third Wednesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Dan Danieley, Executive Director\u00A0\u00A0\u00A0\u00A0\u00A0 336-227-0771",
+        "id": 255
+      },
+      "geometry": {
+        "longitude": -79.476222,
+        "latitude": 36.048977,
+        "coordinates": [
+          -79.476222,
+          36.048977
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Library Committee",
+        "location": "One of the four libraries",
+        "address": "Durham County Library - South Regional, 4505 S Alston Ave, Durham, North Carolina 27713, United States",
+        "schedule": "Alternates meeting times between 12:30 p.m. and 6:30pm four times a year",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Susana Goldman, Director of Alamance County Public Libraries 336-229-3588",
+        "id": 256
+      },
+      "geometry": {
+        "longitude": -78.888448,
+        "latitude": 35.9023,
+        "coordinates": [
+          -78.888448,
+          35.9023
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Public Transit Advisory Commission (PTAC)",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/public-transit-advisory-commission-ptac/",
+        "id": 257
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Recreation and Parks Commission",
+        "location": "Alamance NC",
+        "address": "Alamance, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www.alamance-nc.com/boardscommittees/boards-and-committees/other-boards-and-committees/recreation-and-parks-commission/",
+        "id": 258
+      },
+      "geometry": {
+        "longitude": -79.485855,
+        "latitude": 36.035136,
+        "coordinates": [
+          -79.485855,
+          36.035136
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Tourism Development Authority",
+        "location": "Chamber of Commerce/Visitor Bureau",
+        "address": "Durham Chamber of Commerce, 300 W Morgan St, Durham, North Carolina 27701, United States",
+        "schedule": "10:30 a.m. on the fourth Tuesday of every month.\u00A0 Changes will be posted at https://www.visitalamance.com/about/tourism-development-authority/",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Grace VandeViser, Executive Director (336) 570-1444",
+        "id": 259
+      },
+      "geometry": {
+        "longitude": -78.902268,
+        "latitude": 35.99853,
+        "coordinates": [
+          -78.902268,
+          35.99853
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Alamance",
+        "publicbody": "Veterans Service Committee",
+        "location": "Veterans Service Office",
+        "address": "TS Designs, 2053 Willow Spring Ln, Burlington, North Carolina 27215, United States",
+        "schedule": "As called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "Tammy Crawford, Veterans Service Officer\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 336-570-6763",
+        "id": 260
+      },
+      "geometry": {
+        "longitude": -79.486391,
+        "latitude": 36.049856,
+        "coordinates": [
+          -79.486391,
+          36.049856
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
         "government": "Cumberland",
         "publicbody": "A.B.C. Board",
         "location": "ABC Board Office Conference Room \n424 Person Street\nFayetteville, NC",
-        "address": "ABC Board Office Conference Room \n424 Person Street\nFayetteville, NC",
+        "address": "Person Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Second Monday of each month at 6:00 p.m. The average length of a meeting is approximately two hours.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "50cd1d69-fac3-4065-8a31-9be0d27fdafa"
+        "id": 261
       },
       "geometry": {
-        "longitude": -78.870995,
-        "latitude": 35.049355,
+        "longitude": -78.86733,
+        "latitude": 35.04916,
         "coordinates": [
-          -78.870995,
-          35.049355
+          -78.86733,
+          35.04916
         ],
         "type": "Point"
       },
@@ -31,11 +3895,11 @@
         "location": "Various adult care homes in Cumberland County",
         "address": "Cumberland County, North Carolina, United States",
         "schedule": "Third Thursday of the last month of each quarter at 1:00 p.m. There is an initial training period of 15 hours to include study of a committee handbook and orientation visits to long-term care facilities. Additional training of 10 hours per year is required. Visits in the assigned facilities are of the utmost importance in the participation on this committee. A commitment of at least one day per quarter to visit facilities and 4 hours per quarter for business and training meetings.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "15f93150-527e-4b53-8d68-38bd54986669"
+        "id": 262
       },
       "geometry": {
         "longitude": -78.83,
@@ -53,13 +3917,13 @@
         "government": "Cumberland",
         "publicbody": "Animal Services Board",
         "location": "Animal\u00A0Services Department \n4704 Corporation Drive \nFayetteville, NC",
-        "address": "Animal\u00A0Services Department \n4704 Corporation Drive \nFayetteville, NC",
+        "address": "4704 Corporation Drive, Fayetteville, North Carolina 28306, United States",
         "schedule": "First Monday of every other month (Feb./Apr./June/Aug./Oct./Dec.) at 6:00 p.m. (No meetings held on first or last day of any month.) The average length of a meeting varies.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "c5032f75-258e-48f6-829d-c00da538b481"
+        "id": 263
       },
       "geometry": {
         "longitude": -78.889975,
@@ -77,13 +3941,13 @@
         "government": "Cumberland",
         "publicbody": "Board of Adjustment",
         "location": "Historic Cumberland County Courthouse, Hearing Room #3 \n130 Gillespie Street \nFayetteville, NC",
-        "address": "Historic Cumberland County Courthouse, Hearing Room #3 \n130 Gillespie Street \nFayetteville, NC",
+        "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Third Thursday of each month at 6:00 p.m. The average length of a meeting varies. Each member spends approximately three hours per month in service to this board.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "04cd10e2-edb0-4824-8a85-7aa439b34faf"
+        "id": 264
       },
       "geometry": {
         "longitude": -78.87914,
@@ -101,20 +3965,20 @@
         "government": "Cumberland",
         "publicbody": "Board of Health",
         "location": "Cumberland County Health Department \nBoard Room \n1235 Ramsey Street \nFayetteville, NC",
-        "address": "Cumberland County Health Department \nBoard Room \n1235 Ramsey Street \nFayetteville, NC",
+        "address": "Ramsey Street, Fayetteville, North Carolina 28311, United States",
         "schedule": "Third Tuesday of each month at 6:00 p.m. July and September meetings take place only if desired.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "495852c8-37fe-4f4e-8d1f-4ba791bb3a64"
+        "id": 265
       },
       "geometry": {
-        "longitude": -78.88205,
-        "latitude": 35.07386,
+        "longitude": -78.85364,
+        "latitude": 35.16869,
         "coordinates": [
-          -78.88205,
-          35.07386
+          -78.85364,
+          35.16869
         ],
         "type": "Point"
       },
@@ -125,13 +3989,13 @@
         "government": "Cumberland",
         "publicbody": "Cape Fear Valley Health System Board of Trustees",
         "location": "Cape Fear Valley Health System \nBoard Room First Floor/Administrative Area \n1638 Owen Drive\nFayetteville, NC",
-        "address": "Cape Fear Valley Health System \nBoard Room First Floor/Administrative Area \n1638 Owen Drive\nFayetteville, NC",
+        "address": "Cape Fear, North Carolina, United States",
         "schedule": "Last Wednesday of each month at\u00A05:30 p.m. (No April or July Meeting; November \u0026 December meeting combined)",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "7686dae4-e604-4cc5-bd8b-525093cef4c9"
+        "id": 266
       },
       "geometry": {
         "longitude": -78.814741,
@@ -149,13 +4013,13 @@
         "government": "Cumberland",
         "publicbody": "Civic Center Commission",
         "location": "Cumberland County Civic Center \nCrown Coliseum Board Room \n1960 Coliseum Drive \nFayetteville, NC",
-        "address": "Cumberland County Civic Center \nCrown Coliseum Board Room \n1960 Coliseum Drive \nFayetteville, NC",
+        "address": "Cumberland County, North Carolina, United States",
         "schedule": "Fourth Tuesday of each month at 5:30 p.m. The Board is also divided into three subcommittees that meet on a monthly basis: Finance Committee, Capital Improvements Committee, and Marketing and Sales Committee.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "7d338510-afd2-4235-ac57-f3bc5d22b692"
+        "id": 267
       },
       "geometry": {
         "longitude": -78.83,
@@ -173,20 +4037,20 @@
         "government": "Cumberland",
         "publicbody": "Cumberland County Cemetery Commission",
         "location": "As called",
-        "address": "Cumberland County, North Carolina, United States",
+        "address": "Cumberland Street, Newport, North Carolina 28570, United States",
         "schedule": "Meets on an as-needed basis",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "d1e8a5fc-f0e9-4be2-a950-69776e46e896"
+        "id": 268
       },
       "geometry": {
-        "longitude": -78.83,
-        "latitude": 35.05,
+        "longitude": -76.98508,
+        "latitude": 34.71181,
         "coordinates": [
-          -78.83,
-          35.05
+          -76.98508,
+          34.71181
         ],
         "type": "Point"
       },
@@ -197,13 +4061,13 @@
         "government": "Cumberland",
         "publicbody": "Cumberland County Community Child Protection/Fatality Prevention Team",
         "location": "Department of Social Services Building\n4th Floor, Room 440 \n1225 Ramsey Street\nFayetteville, NC",
-        "address": "Department of Social Services Building\n4th Floor, Room 440 \n1225 Ramsey Street\nFayetteville, NC",
+        "address": "1225 Ramsey Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Third Thursday of each month at 3:00 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "ccb9db29-b26d-44da-a4c3-b29eab058952"
+        "id": 269
       },
       "geometry": {
         "longitude": -78.88209,
@@ -221,13 +4085,13 @@
         "government": "Cumberland",
         "publicbody": "Cumberland County Finance Corporation",
         "location": "Cumberland County Courthouse, Room 564 \n117 Dick Street \nFayetteville, NC",
-        "address": "Cumberland County Courthouse, Room 564 \n117 Dick Street \nFayetteville, NC",
+        "address": "117 Dick Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Meetings are held on an as needed basis usually at 12:00 p.m. The length of the meetings varies.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "a68ced5b-86bd-42ec-985a-a5d93d1989ae"
+        "id": 270
       },
       "geometry": {
         "longitude": -78.87624,
@@ -247,11 +4111,11 @@
         "location": "Various service provider locations within Cumberland County",
         "address": "CenturyLink, 717 Mcgilvary St, Fayetteville, North Carolina 28301, United States",
         "schedule": "Meets as needed.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "02231dc7-9b82-4ff9-a6d4-1b77e669cd54"
+        "id": 271
       },
       "geometry": {
         "longitude": -78.890066,
@@ -269,13 +4133,13 @@
         "government": "Cumberland",
         "publicbody": "Cumberland County Industrial Facilities and Pollution Control Financing Authority",
         "location": "Cumberland County Courthouse, \nRoom 564 \n117 Dick Street \nFayetteville, NC",
-        "address": "Cumberland County Courthouse, \nRoom 564 \n117 Dick Street \nFayetteville, NC",
+        "address": "117 Dick Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Meetings are held on an as needed basis usually at 12:00 PM. The length of the meetings varies.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "2a5159e4-ce36-4a7a-a8d2-4bc7da2f05f9"
+        "id": 272
       },
       "geometry": {
         "longitude": -78.87624,
@@ -293,20 +4157,20 @@
         "government": "Cumberland",
         "publicbody": "Cumberland County Juvenile Crime Prevention Council",
         "location": "Cumberland County CommuniCare, \nLower Level Conference Room \n109 Bradford Ave \nFayetteville, NC 28301",
-        "address": "Cumberland County CommuniCare, \nLower Level Conference Room \n109 Bradford Ave \nFayetteville, NC 28301",
+        "address": "Bradford Avenue, Fayetteville, North Carolina 28301, United States",
         "schedule": "Second Wednesday of each month at 1:15 p.m. Meetings are normally one to two hours in length.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "ab026f0f-f68a-4ccf-a8e9-59b00a32d8fe"
+        "id": 273
       },
       "geometry": {
-        "longitude": -78.89155,
-        "latitude": 35.055465,
+        "longitude": -78.89288,
+        "latitude": 35.05289,
         "coordinates": [
-          -78.89155,
-          35.055465
+          -78.89288,
+          35.05289
         ],
         "type": "Point"
       },
@@ -317,20 +4181,20 @@
         "government": "Cumberland",
         "publicbody": "Cumberland County Local Emergency Planning Committee",
         "location": "Rotating Locations",
-        "address": "Cumberland County, North Carolina, United States",
+        "address": "Cumberland Street, Newport, North Carolina 28570, United States",
         "schedule": "On the last Thursday of the first month of each quarter at 10:00 a.m. Members are also required to attend and work with the subcommittee they are assigned to. The meetings generally last approximately one hour. The time required for the subcommittee would vary depending on the nature of the subcommittee (i.e., Membership, Resources, Exercise, Planning, etc.)",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "ddce45e5-ed7a-494b-8f53-4347f9553764"
+        "id": 274
       },
       "geometry": {
-        "longitude": -78.83,
-        "latitude": 35.05,
+        "longitude": -76.98508,
+        "latitude": 34.71181,
         "coordinates": [
-          -78.83,
-          35.05
+          -76.98508,
+          34.71181
         ],
         "type": "Point"
       },
@@ -341,20 +4205,20 @@
         "government": "Cumberland",
         "publicbody": "Cumberland County Workforce Development Board",
         "location": "FTCC General Classroom Building\nRoom 114\n2817 Ft. Bragg Rd",
-        "address": "D-3229 Barracks, D-3229 Ardennes Rd, Fort Bragg, North Carolina 28307, United States",
+        "address": "Soldier Support Center, 4-2843 Normandy Dr # 284-28433, Fort Bragg, North Carolina 28307, United States",
         "schedule": "Third Tuesday\u00A0of every other month at 11:00\u00A0a.m. (starting in January)",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "5a2b7c05-69f8-4ba7-85bf-442531dd3f6d"
+        "id": 275
       },
       "geometry": {
-        "longitude": -79.004488,
-        "latitude": 35.126227,
+        "longitude": -79.001217,
+        "latitude": 35.139046,
         "coordinates": [
-          -79.004488,
-          35.126227
+          -79.001217,
+          35.139046
         ],
         "type": "Point"
       },
@@ -365,13 +4229,13 @@
         "government": "Cumberland",
         "publicbody": "Equalization and Review Board",
         "location": "Cumberland County Courthouse, \nRoom 564 \n117 Dick Street \nFayetteville, NC",
-        "address": "Cumberland County Courthouse, \nRoom 564 \n117 Dick Street \nFayetteville, NC",
+        "address": "117 Dick Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "2nd Wednesday of every month (except July) at 3:00 p.m. The Regular Board of Equalization and Review holds its first meeting each year no earlier than the first Monday in April and no later than the first Monday in May. In a year in which a countywide reappraisal (revaluation) is not conducted, the Board must complete its duties on or before the third Monday after they begin their duties, unless in its opinion a longer period is required. However, in no event may they sit longer than July 1st. In a year in which a revaluation is conducted, the Board may sit until December 31st.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "3b5ece4f-de10-45ac-84cf-cf99c0cde0f5"
+        "id": 276
       },
       "geometry": {
         "longitude": -78.87624,
@@ -389,13 +4253,13 @@
         "government": "Cumberland",
         "publicbody": "Farm Advisory Board",
         "location": "Historic Cumberland County Courthouse, \nRoom 107C \n130 Gillespie Street \nFayetteville, NC",
-        "address": "Historic Cumberland County Courthouse, \nRoom 107C \n130 Gillespie Street \nFayetteville, NC",
+        "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Quarterly - second Tuesday of the first month at 7:00 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "94baafbb-f419-4016-bcf7-75a4b36ace5b"
+        "id": 277
       },
       "geometry": {
         "longitude": -78.87914,
@@ -413,13 +4277,13 @@
         "government": "Cumberland",
         "publicbody": "Fayetteville Area Convention and Visitors Bureau Board of Directors",
         "location": "Fayetteville Area Convention and Visitors Bureau \nBoard Room\n245 Person Street\n\nFayetteville, NC",
-        "address": "Fayetteville Area Convention and Visitors Bureau \nBoard Room\n245 Person Street\n\nFayetteville, NC",
+        "address": "Fayetteville Area Convention and Visitors Bureau, 245 Person St, Fayetteville, North Carolina 28301, United States",
         "schedule": "Quarterly on 4th Wednesday (starting in January) at 12:00 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "91968bfa-2b59-4867-8ba3-6aa06cdea496"
+        "id": 278
       },
       "geometry": {
         "longitude": -78.874542,
@@ -437,13 +4301,13 @@
         "government": "Cumberland",
         "publicbody": "Fayetteville Cumberland County Economic Development Corporation",
         "location": "201 Hay Street\nR. B. Williams Building Ste 401A\nFayetteville, NC",
-        "address": "201 Hay Street\nR. B. Williams Building Ste 401A\nFayetteville, NC",
+        "address": "Fayetteville, North Carolina, United States",
         "schedule": "Second Tuesday of each month at\u00A08:00 a.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "7173591b-c6f7-4a94-86ad-e5a0c7b47db6"
+        "id": 279
       },
       "geometry": {
         "longitude": -78.878292,
@@ -461,13 +4325,13 @@
         "government": "Cumberland",
         "publicbody": "Fayetteville Technical Community College Board of Trustees",
         "location": "Fayetteville Technical Community College, \nBoard Room Tony Rand Student Center \n2201 Hull Road \nFayetteville, NC",
-        "address": "Fayetteville Technical Community College, \nBoard Room Tony Rand Student Center \n2201 Hull Road \nFayetteville, NC",
+        "address": "Fayetteville, North Carolina, United States",
         "schedule": "The third Monday of each month at 12:30 p.m. No meetings in July and December. The maximum time per meeting would be four hours which includes committee meetings and lunch. Called meetings do occur occasionally and trustees are encouraged to attend some organizational meetings out of town or out of state. The Board is also divided into five sub committees that meet on the third Monday of each month prior to the 12:45 PM, Board Meeting, except July and December: (1) Finance Committee; (2) Human Resources Committee; (3) Building and Grounds Committee; and (4) Curriculum Committee; and (5) Planning Committee.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "9cbc7024-d992-434e-a03f-5409da38c234"
+        "id": 280
       },
       "geometry": {
         "longitude": -78.878292,
@@ -485,13 +4349,13 @@
         "government": "Cumberland",
         "publicbody": "Fayetteville-Cumberland Parks and Recreation Advisory Commission",
         "location": "City of Fayetteville Parks \u0026 Recreation\n121 Lamon Street \nFayetteville, NC",
-        "address": "City of Fayetteville Parks \u0026 Recreation\n121 Lamon Street \nFayetteville, NC",
+        "address": "121 Lamon Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "1st Tuesday of every month at 5:30 p.m. Meetings last one to one and one-half hours with occasional committee meetings as needed.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "3ff3bf5c-a155-4ed5-a0ef-ab9abb9e57e5"
+        "id": 281
       },
       "geometry": {
         "longitude": -78.87519,
@@ -509,13 +4373,13 @@
         "government": "Cumberland",
         "publicbody": "Human Relations Commission",
         "location": "Festival Park Plaza Training Room 1st Floor\n225 Ray Ave\nFayetteville, NC 28301",
-        "address": "Festival Park Plaza Training Room 1st Floor\n225 Ray Ave\nFayetteville, NC 28301",
+        "address": "225 Ray Avenue, Fayetteville, North Carolina 28301, United States",
         "schedule": "Second Thursday of every month at 5:30 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "1e748f24-ccef-47a3-b69d-90088472002e"
+        "id": 282
       },
       "geometry": {
         "longitude": -78.88183,
@@ -535,11 +4399,11 @@
         "location": "Fayetteville City Hall\nE.E. Smith Conference Room",
         "address": "Fayetteville, North Carolina, United States",
         "schedule": "Second\u00A0Monday\u00A0of the month at 5:30 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "fef7419e-3622-4cb8-a541-1246a6e69d97"
+        "id": 283
       },
       "geometry": {
         "longitude": -78.878292,
@@ -557,13 +4421,13 @@
         "government": "Cumberland",
         "publicbody": "Joint Fort Bragg \u0026 Cumberland County Food Policy Council",
         "location": "1235 Ramsey Street, Fayetteville, NC",
-        "address": "1235 Ramsey Street, Fayetteville, NC",
+        "address": "1235 Ramsey Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "First Wednesday of Each Month \n\n    Odd numbered days @ 5 p.m.\n    Even numbered days @ 12 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "ef069712-d958-4294-bd56-dbeac173bbd1"
+        "id": 284
       },
       "geometry": {
         "longitude": -78.88205,
@@ -581,20 +4445,20 @@
         "government": "Cumberland",
         "publicbody": "Joint Planning Board",
         "location": "Historic Cumberland County Courthouse\nHearing Room #3 \n130 Gillespie Street \nFayetteville, North Carolina",
-        "address": "Cumberland County, North Carolina, United States",
+        "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Third Tuesday of each month at 6:00 p.m.\u00A0Meetings vary in length. Members also serve on sub-committees (Administrative, Comprehensive Planning, Codes and Nominating). These sub-committees meet on an as-needed basis. In addition, time is spent outside of the meetings to review various documents and plans on which the Board is required to vote.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "66cca6bd-e32b-458a-9a40-e4bffaf45dec"
+        "id": 285
       },
       "geometry": {
-        "longitude": -78.83,
-        "latitude": 35.05,
+        "longitude": -78.87914,
+        "latitude": 35.051535,
         "coordinates": [
-          -78.83,
-          35.05
+          -78.87914,
+          35.051535
         ],
         "type": "Point"
       },
@@ -607,11 +4471,11 @@
         "location": "Judge E. Maurice Braswell Courthouse \n3rd Floor \n117 Dick Street, Fayetteville",
         "address": "Fayetteville, North Carolina, United States",
         "schedule": "The Jury Commission meets at least twice a year. The Commission is responsible to meet as often as required to complete the jury list for the next year by the 30th day of November of each year. The amount of time required for each meeting and the number of meetings required is determined by the Commission and dictated by the procedures that the Commission chooses to prepare the Master List.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "56b90332-f292-4542-ad54-056152e6937c"
+        "id": 286
       },
       "geometry": {
         "longitude": -78.878292,
@@ -629,20 +4493,20 @@
         "government": "Cumberland",
         "publicbody": "Library Board of Trustees",
         "location": "Various libraries throughout the County",
-        "address": "Hope Mills Public Library, 3411 Golfview Rd, Hope Mills, North Carolina 28348, United States",
+        "address": "The Country, Burlington, North Carolina, United States",
         "schedule": "Third Thursday of each month at 9:05 a.m. (except for December). The approximate amount of time a Library Trustee would devote to the Board each month is two hours for meeting attendance with variable preparation and follow-up time. Periodic committee meeting attendance may be required. Trustee committees are: By-Laws (on call) and Nominating (on call).",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "f6932724-2bf6-46fc-a1d9-9fa3a6d586e3"
+        "id": 287
       },
       "geometry": {
-        "longitude": -78.95902,
-        "latitude": 34.974601,
+        "longitude": -79.5178,
+        "latitude": 36.046247,
         "coordinates": [
-          -78.95902,
-          34.974601
+          -79.5178,
+          36.046247
         ],
         "type": "Point"
       },
@@ -653,20 +4517,20 @@
         "government": "Cumberland",
         "publicbody": "Mid-Carolina Aging Advisory Council",
         "location": "Various locations in the three county region (Cumberland, Harnett and Sampson counties)",
-        "address": "Cumberland County, North Carolina, United States",
+        "address": "Sampson County, North Carolina, United States",
         "schedule": "First\u00A0Thursday of the\u00A0last month of each quarter at 2:00 p.m. Length of meetings varies.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "8e15dee8-cd65-407a-bb1b-c8ecdd4f01d4"
+        "id": 288
       },
       "geometry": {
-        "longitude": -78.83,
-        "latitude": 35.05,
+        "longitude": -78.37,
+        "latitude": 34.99,
         "coordinates": [
-          -78.83,
-          35.05
+          -78.37,
+          34.99
         ],
         "type": "Point"
       },
@@ -677,13 +4541,13 @@
         "government": "Cumberland",
         "publicbody": "North Carolina Southeast",
         "location": "70 West Broad Street, Elizabethtown, NC",
-        "address": "70 West Broad Street, Elizabethtown, NC",
+        "address": "70 West Broad Street, Elizabethtown, North Carolina 28337, United States",
         "schedule": "Quarterly",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "b29a3a9f-cfa7-4c2d-879f-6a2f36a48681"
+        "id": 289
       },
       "geometry": {
         "longitude": -78.605956,
@@ -703,11 +4567,11 @@
         "location": "Various nursing homes in Cumberland County",
         "address": "Cumberland County, North Carolina, United States",
         "schedule": "Third Thursday of the last month of each quarter at 10:00 a.m. There is an initial training period of 15 hours to include study of a committee handbook and orientation visits to long-term care facilities. Additional training of 10 hours per year is required. Visits in the assigned facilities are of the utmost importance in the participation on this committee. A commitment of at least one day per quarter to visit facilities and 4 hours per quarter for business and training meetings.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "a18e46ca-ecd3-40cf-823b-b5d3e5e5c4f5"
+        "id": 290
       },
       "geometry": {
         "longitude": -78.83,
@@ -725,13 +4589,13 @@
         "government": "Cumberland",
         "publicbody": "Senior Citizens Advisory Commission",
         "location": "FCPR Senior Center, Large Program Room\n739 Blue Street\nFayetteville, NC",
-        "address": "FCPR Senior Center, Large Program Room\n739 Blue Street\nFayetteville, NC",
+        "address": "Blue Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "Second Tuesday of each month at 2:30 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "9a3b11cc-1d06-413a-86c4-65ccfb57dc41"
+        "id": 291
       },
       "geometry": {
         "longitude": -78.89206,
@@ -749,20 +4613,20 @@
         "government": "Cumberland",
         "publicbody": "Social Services Board",
         "location": "Department of Social Services, \nBoard Room \n1225 Ramsey Street\nFayetteville, NC",
-        "address": "Department of Social Services, \nBoard Room \n1225 Ramsey Street\nFayetteville, NC",
+        "address": "Ramsey Street, Fayetteville, North Carolina 28311, United States",
         "schedule": "Last Wednesday of each month at 1:00 p.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "bde55de6-8cb1-4047-94de-2f23e9082817"
+        "id": 292
       },
       "geometry": {
-        "longitude": -79.778167,
-        "latitude": 36.091909,
+        "longitude": -78.85364,
+        "latitude": 35.16869,
         "coordinates": [
-          -79.778167,
-          36.091909
+          -78.85364,
+          35.16869
         ],
         "type": "Point"
       },
@@ -773,13 +4637,13 @@
         "government": "Cumberland",
         "publicbody": "Southeastern Economic Development Commission",
         "location": "707 West Broad Street, \nElizabethtown, NC",
-        "address": "707 West Broad Street, \nElizabethtown, NC",
+        "address": "707 West Broad Street, Elizabethtown, North Carolina 28337, United States",
         "schedule": "Full Board meets one time annually - Usually in April",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "ae74b708-2b73-481f-98c3-63fb05263d3c"
+        "id": 293
       },
       "geometry": {
         "longitude": -78.613504,
@@ -797,13 +4661,13 @@
         "government": "Cumberland",
         "publicbody": "Transportation Advisory Board",
         "location": "Historic Cumberland County Courthouse \nHearing Room #3\n130 Gillespie Street \nFayetteville, NC",
-        "address": "Historic Cumberland County Courthouse \nHearing Room #3\n130 Gillespie Street \nFayetteville, NC",
+        "address": "130 Gillespie Street, Fayetteville, North Carolina 28301, United States",
         "schedule": "The\u00A0second Tuesday of the first month in the quarter, (January, April, July, and October) at 10:00 a.m.",
-        "start": null,
-        "end": null,
+        "start": "",
+        "end": "",
         "remote": "",
         "moreInfo": "https://www.cumberlandcountync.gov/departments/commissioners-group/commissioners/appointed-boards/board-descriptions",
-        "id": "3e5d8198-69e5-46ac-8168-b9ff2199c25a"
+        "id": 294
       },
       "geometry": {
         "longitude": -78.87914,
@@ -811,6 +4675,1326 @@
         "coordinates": [
           -78.87914,
           35.051535
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Agenda Review",
+        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
+        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
+        "schedule": "2022-09-15T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-82/",
+        "id": 295
+      },
+      "geometry": {
+        "longitude": -77.867841,
+        "latitude": 34.24198,
+        "coordinates": [
+          -77.867841,
+          34.24198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Regular Meeting",
+        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
+        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
+        "schedule": "2022-09-19T09:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-159/",
+        "id": 296
+      },
+      "geometry": {
+        "longitude": -77.945692,
+        "latitude": 34.23618,
+        "coordinates": [
+          -77.945692,
+          34.23618
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Agenda Review",
+        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
+        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
+        "schedule": "2022-09-29T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-81/",
+        "id": 297
+      },
+      "geometry": {
+        "longitude": -77.867841,
+        "latitude": 34.24198,
+        "coordinates": [
+          -77.867841,
+          34.24198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Regular Meeting",
+        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
+        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
+        "schedule": "2022-10-03T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-160/",
+        "id": 298
+      },
+      "geometry": {
+        "longitude": -77.945692,
+        "latitude": 34.23618,
+        "coordinates": [
+          -77.945692,
+          34.23618
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Agenda Review",
+        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
+        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
+        "schedule": "2022-10-13T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-83/",
+        "id": 299
+      },
+      "geometry": {
+        "longitude": -77.867841,
+        "latitude": 34.24198,
+        "coordinates": [
+          -77.867841,
+          34.24198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Regular Meeting",
+        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
+        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
+        "schedule": "2022-10-17T09:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-161/",
+        "id": 300
+      },
+      "geometry": {
+        "longitude": -77.945692,
+        "latitude": 34.23618,
+        "coordinates": [
+          -77.945692,
+          34.23618
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Agenda Review",
+        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
+        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
+        "schedule": "2022-11-10T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-84/",
+        "id": 301
+      },
+      "geometry": {
+        "longitude": -77.867841,
+        "latitude": 34.24198,
+        "coordinates": [
+          -77.867841,
+          34.24198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Regular Meeting",
+        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
+        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
+        "schedule": "2022-11-14T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-162/",
+        "id": 302
+      },
+      "geometry": {
+        "longitude": -77.945692,
+        "latitude": 34.23618,
+        "coordinates": [
+          -77.945692,
+          34.23618
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Agenda Review",
+        "location": "NHC Government Center - Conference Room 601 @ 230 Government Center Dr, Wilmington, NC 28403, USA",
+        "address": "230 Government Center Drive, Wilmington, North Carolina 28403, United States",
+        "schedule": "2022-12-01T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-agenda-review-85/",
+        "id": 303
+      },
+      "geometry": {
+        "longitude": -77.867841,
+        "latitude": 34.24198,
+        "coordinates": [
+          -77.867841,
+          34.24198
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "New Hannover",
+        "publicbody": "Board of Commissioners Regular Meeting",
+        "location": "NHC Courthouse - Room 301 @ 24 N 3rd St, Wilmington, NC 28401, USA",
+        "address": "24 North 3rd Street, Wilmington, North Carolina 28401, United States",
+        "schedule": "2022-12-05T16:00:00",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://commissioners.nhcgov.com/event/board-of-commissioners-regular-meeting-163/",
+        "id": 304
+      },
+      "geometry": {
+        "longitude": -77.945692,
+        "latitude": 34.23618,
+        "coordinates": [
+          -77.945692,
+          34.23618
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Avery",
+        "publicbody": "Veterans Day - County Offices Closed",
+        "location": "VEVENT",
+        "address": "Avery Street, Morehead City, North Carolina 28557, United States",
+        "schedule": "11/11/2022 12:00:00 AM America/New_York",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 305
+      },
+      "geometry": {
+        "longitude": -76.72044,
+        "latitude": 34.7253,
+        "coordinates": [
+          -76.72044,
+          34.7253
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Avery",
+        "publicbody": "Thanksgiving Holiday - County Offices Closed",
+        "location": "VEVENT",
+        "address": "Avery Street, Morehead City, North Carolina 28557, United States",
+        "schedule": "11/24/2022 12:00:00 AM America/New_York",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 306
+      },
+      "geometry": {
+        "longitude": -76.72044,
+        "latitude": 34.7253,
+        "coordinates": [
+          -76.72044,
+          34.7253
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Avery",
+        "publicbody": "Christmas Holiday - County Offices Closed",
+        "location": "VEVENT",
+        "address": "Avery Street, Morehead City, North Carolina 28557, United States",
+        "schedule": "12/23/2022 12:00:00 AM America/New_York",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 307
+      },
+      "geometry": {
+        "longitude": -76.72044,
+        "latitude": 34.7253,
+        "coordinates": [
+          -76.72044,
+          34.7253
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Avery",
+        "publicbody": "Christmas Holiday - County Offices Closed",
+        "location": "VEVENT",
+        "address": "Avery Street, Morehead City, North Carolina 28557, United States",
+        "schedule": "12/26/2022 12:00:00 AM America/New_York",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "",
+        "id": 308
+      },
+      "geometry": {
+        "longitude": -76.72044,
+        "latitude": 34.7253,
+        "coordinates": [
+          -76.72044,
+          34.7253
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Adult Care Home Community Advisory Committee",
+        "location": "Seymour Center",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "4:00 pm - 5:30 pm First Tuesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=47",
+        "id": 309
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Advisory Board on Aging",
+        "location": "Passmore Center \u0026 Seymour Center (altnernating)",
+        "address": "North Carolina, United States",
+        "schedule": "1:00 pm Second Tuesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=34",
+        "id": 310
+      },
+      "geometry": {
+        "longitude": -79.3896838690365,
+        "latitude": 35.5568849207,
+        "coordinates": [
+          -79.3896838690365,
+          35.5568849207
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Affordable Housing Advisory Board",
+        "location": "",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:00 pm Second Tuesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=990744288",
+        "id": 311
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Agricultural Preservation Board",
+        "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
+        "address": "Davis, North Carolina, United States",
+        "schedule": "6:30 pm (winter) 7:30 pm (spring, summer, fall) Third Wednesday of every other month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=25",
+        "id": 312
+      },
+      "geometry": {
+        "longitude": -76.460199,
+        "latitude": 34.797385,
+        "coordinates": [
+          -76.460199,
+          34.797385
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Alcoholic Beverage Control Board",
+        "location": "601 Valley Forge Road, Hillsborough",
+        "address": "601 Valley Forge Road, Hillsborough, North Carolina 27278, United States",
+        "schedule": "8:30 am Third Tuesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=38",
+        "id": 313
+      },
+      "geometry": {
+        "longitude": -79.087285,
+        "latitude": 36.063205,
+        "coordinates": [
+          -79.087285,
+          36.063205
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Animal Services Advisory Board",
+        "location": "Community Room of the Animal Services Facility",
+        "address": "I-73 S/ US Hwy 220 Rest Stop, I-73 South, Seagrove, North Carolina 27341, United States",
+        "schedule": "6:30 pm Third Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144669",
+        "id": 314
+      },
+      "geometry": {
+        "longitude": -79.784458,
+        "latitude": 35.513108,
+        "coordinates": [
+          -79.784458,
+          35.513108
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Animal Services Hearing Panel Pool",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "As Needed As Needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144711",
+        "id": 315
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Arts Commission",
+        "location": "Alternating",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:00 pm Second Monday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=49",
+        "id": 316
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Board of Equalization and Review (REQUIRES DISCLOSURE STATEMENT)",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "As needed As needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=52",
+        "id": 317
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Board of Health",
+        "location": "C.H. \u0026 Hillsborough Health Depts. (alternating)",
+        "address": "Hillsborough, North Carolina, United States",
+        "schedule": "7:00 pm Fourth Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=7",
+        "id": 318
+      },
+      "geometry": {
+        "longitude": -79.099228,
+        "latitude": 36.07523,
+        "coordinates": [
+          -79.099228,
+          36.07523
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Board of Social Services",
+        "location": "Hillsborough Commons Board Room",
+        "address": "Hillsborough, North Carolina, United States",
+        "schedule": "4:00 pm Third Monday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=11",
+        "id": 319
+      },
+      "geometry": {
+        "longitude": -79.099228,
+        "latitude": 36.07523,
+        "coordinates": [
+          -79.099228,
+          36.07523
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Carrboro Board of Adjustment",
+        "location": "Carrboro Town Hall",
+        "address": "Carrboro Town Hall, 301 W Main St, Carrboro, North Carolina 27510, United States",
+        "schedule": "7:00 pm Third Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=17",
+        "id": 320
+      },
+      "geometry": {
+        "longitude": -79.077495,
+        "latitude": 35.911409,
+        "coordinates": [
+          -79.077495,
+          35.911409
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Carrboro Northern Transition Area Advisory Committee",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "Meets as called Meets as called",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=64",
+        "id": 321
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Carrboro Planning Board",
+        "location": "Carrboro Town Hall",
+        "address": "Carrboro Town Hall, 301 W Main St, Carrboro, North Carolina 27510, United States",
+        "schedule": "7:30 pm First and Third Thursday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=15",
+        "id": 322
+      },
+      "geometry": {
+        "longitude": -79.077495,
+        "latitude": 35.911409,
+        "coordinates": [
+          -79.077495,
+          35.911409
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Chapel Hill Board of Adjustment",
+        "location": "Chapel Hill Town Hall",
+        "address": "Chapel Hill, North Carolina, United States",
+        "schedule": "7:30 pm First Wednesday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=24",
+        "id": 323
+      },
+      "geometry": {
+        "longitude": -79.05578,
+        "latitude": 35.913154,
+        "coordinates": [
+          -79.05578,
+          35.913154
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Chapel Hill Library Advisory Board",
+        "location": "Chapel Hill Public Library Meeting Room C",
+        "address": "Chapel Hill Public Library, 100 Library Dr, Chapel Hill, North Carolina 27514, United States",
+        "schedule": "5:30 pm Second Monday in Feb, May, Sep, \u0026 Nov",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144701",
+        "id": 324
+      },
+      "geometry": {
+        "longitude": -79.035588,
+        "latitude": 35.932167,
+        "coordinates": [
+          -79.035588,
+          35.932167
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Chapel Hill Orange County Visitors Bureau Advisory Board",
+        "location": "Varies",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "8:00 am Third Wednesday of every month except Jul. \u0026 Dec.",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=6",
+        "id": 325
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Chapel Hill Parks, Greenways and Recreation Commission",
+        "location": "Chapel Hill Public Library",
+        "address": "Chapel Hill Public Library, 100 Library Dr, Chapel Hill, North Carolina 27514, United States",
+        "schedule": "7:00 pm Third Tuesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144672",
+        "id": 326
+      },
+      "geometry": {
+        "longitude": -79.035588,
+        "latitude": 35.932167,
+        "coordinates": [
+          -79.035588,
+          35.932167
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Chapel Hill Planning Commission",
+        "location": "Chapel Hill Town Council",
+        "address": "Chapel Hill, North Carolina, United States",
+        "schedule": "7:00 pm First and third Tuesday of every month except July",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=13",
+        "id": 327
+      },
+      "geometry": {
+        "longitude": -79.05578,
+        "latitude": 35.913154,
+        "coordinates": [
+          -79.05578,
+          35.913154
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Commission for the Environment",
+        "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
+        "address": "Davis, North Carolina, United States",
+        "schedule": "7:00 pm Second Monday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=54",
+        "id": 328
+      },
+      "geometry": {
+        "longitude": -76.460199,
+        "latitude": 34.797385,
+        "coordinates": [
+          -76.460199,
+          34.797385
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Durham Technical Community College Board of Trustees",
+        "location": "Lyon Board Room, Durham Tech Main Campus",
+        "address": "Durham, North Carolina, United States",
+        "schedule": "3:00 pm Varies",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144690",
+        "id": 329
+      },
+      "geometry": {
+        "longitude": -78.901805,
+        "latitude": 35.996653,
+        "coordinates": [
+          -78.901805,
+          35.996653
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Economic Development Advisory Board (REQUIRES DISCLOSURE STATEMENT)",
+        "location": "Rotating",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "12:00 pm Second Tuesday of every other month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144706",
+        "id": 330
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Hillsborough Board of Adjustment",
+        "location": "Hillsborough Town Hall Annex",
+        "address": "Hillsborough, North Carolina, United States",
+        "schedule": "7:00 pm Second  Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=50",
+        "id": 331
+      },
+      "geometry": {
+        "longitude": -79.099228,
+        "latitude": 36.07523,
+        "coordinates": [
+          -79.099228,
+          36.07523
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Hillsborough Planning Board",
+        "location": "Hillsborough Town Hall Annex",
+        "address": "Hillsborough, North Carolina, United States",
+        "schedule": "7:00 pm Third Thursday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=42",
+        "id": 332
+      },
+      "geometry": {
+        "longitude": -79.099228,
+        "latitude": 36.07523,
+        "coordinates": [
+          -79.099228,
+          36.07523
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Historic Preservation Commission (APPLICANTS SHALL RESIDE WITHIN THE TERRITORIAL JURISDICTION OF ORANGE COUNTY)",
+        "location": "Old Orange County Courthouse",
+        "address": "Orange County Courthouse, 106 E Margaret Ln, Hillsborough, North Carolina 27278, United States",
+        "schedule": "7:00 pm Fourth Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=53",
+        "id": 333
+      },
+      "geometry": {
+        "longitude": -79.099206,
+        "latitude": 36.0745765,
+        "coordinates": [
+          -79.099206,
+          36.0745765
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Human Relations Commission",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:00 pm Fourth Tuesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=16",
+        "id": 334
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Jury Commission",
+        "location": "Orange County Courthouse",
+        "address": "Orange County Courthouse, 106 E Margaret Ln, Hillsborough, North Carolina 27278, United States",
+        "schedule": "As needed As needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=10",
+        "id": 335
+      },
+      "geometry": {
+        "longitude": -79.099206,
+        "latitude": 36.0745765,
+        "coordinates": [
+          -79.099206,
+          36.0745765
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Mebane Board of Adjustment",
+        "location": "Mebane Town Hall",
+        "address": "Mebane, North Carolina, United States",
+        "schedule": "6:00 pm First Monday of every month (if necessary)",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=26",
+        "id": 336
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Mebane Planning Board",
+        "location": "Mebane Town Hall",
+        "address": "Mebane, North Carolina, United States",
+        "schedule": "6:30 pm Second Monday of every month (if necessary)",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=32",
+        "id": 337
+      },
+      "geometry": {
+        "longitude": -79.266962,
+        "latitude": 36.095972,
+        "coordinates": [
+          -79.266962,
+          36.095972
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Nursing Home Community Advisory Committee",
+        "location": "Seymour Center, 2551 Homestead Rd., Chapel Hill",
+        "address": "Chapel Hill, North Carolina, United States",
+        "schedule": "5:30 pm First Tuesday of every other month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=4",
+        "id": 338
+      },
+      "geometry": {
+        "longitude": -79.05578,
+        "latitude": 35.913154,
+        "coordinates": [
+          -79.05578,
+          35.913154
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Orange County Board of Adjustment (REQUIRES DISCLOSURE STATEMENT)",
+        "location": "Whitted Building, Room 230",
+        "address": "Orange Street, Beaufort, North Carolina 28516, United States",
+        "schedule": "7:00 pm Second Monday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=46",
+        "id": 339
+      },
+      "geometry": {
+        "longitude": -76.66512,
+        "latitude": 34.72012,
+        "coordinates": [
+          -76.66512,
+          34.72012
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Orange County Housing Authority",
+        "location": "Southern Human Services Center",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:00 pm Third Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144698",
+        "id": 340
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Orange County Parks and Recreation Council",
+        "location": "Bonnie B. Davis Environment \u0026 Agricultural Center",
+        "address": "Davis, North Carolina, United States",
+        "schedule": "6:30 pm First Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=44",
+        "id": 341
+      },
+      "geometry": {
+        "longitude": -76.460199,
+        "latitude": 34.797385,
+        "coordinates": [
+          -76.460199,
+          34.797385
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Orange County Planning Board (REQUIRES DISCLOSURE STATEMENT)",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "7:00 pm First Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=56",
+        "id": 342
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Orange Unified Transportation Board",
+        "location": "West Campus Office Building, Room 204",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:30 pm Third Wednesday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144670",
+        "id": 343
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Orange Water \u0026 Sewer Authority Board of Directors",
+        "location": "OWASA Community Room",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "6:00 pm Second Thursday of every month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=21",
+        "id": 344
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "GoTriangle Special Tax Board (COMMISSIONERS ONLY)",
+        "location": "TBD",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "TBD Once every January; more as needed",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144708",
+        "id": 345
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Joint Orange Chatham Community Action Agency (CURRENTLY NOT ACCEPTING APPLICATIONS)",
+        "location": "alternating locations-Orange/Chatham",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "12:00 or 4:00 pm second Thursday of each month",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=43",
+        "id": 346
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Orange County Climate Council",
+        "location": "TBA",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "TBA TBA",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144716",
+        "id": 347
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Solid Waste Advisory Group (SWAG)",
+        "location": "",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=1258144710",
+        "id": 348
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
+        ],
+        "type": "Point"
+      },
+      "type": "Feature"
+    },
+    {
+      "properties": {
+        "government": "Orange",
+        "publicbody": "Workforce Development Board - Regional Partnership",
+        "location": "Rotates between participating counties",
+        "address": "Orange, North Carolina, United States",
+        "schedule": "day-time meeting quarterly",
+        "start": "",
+        "end": "",
+        "remote": "",
+        "moreInfo": "https://www4.orangecountync.gov/boards/indivbd.asp?BoardID=29",
+        "id": 349
+      },
+      "geometry": {
+        "longitude": -78.522231,
+        "latitude": 35.129611,
+        "coordinates": [
+          -78.522231,
+          35.129611
         ],
         "type": "Point"
       },

--- a/publicmeetings.html
+++ b/publicmeetings.html
@@ -178,7 +178,7 @@
 
             mapboxgl.accessToken = 'pk.eyJ1IjoiY2N0aGVncmVhdCIsImEiOiJjbDI2a2lodnYwMnRnM2ZvdXVhZXNjbHd0In0.4CfhKr_VP1IDEM08Nk7PXg';
             const stateCoords = [-79.8, 35.3] 
-            const defaultZoom = 6
+            const defaultZoom = 7
             const spreadSheetID = '12GiMtxkEZA-TzAB0iBf3S_euXBId7HaPlWUvpOf9p-Q';
             const sheetName = 'all';
             const sheetURI = `https://docs.google.com/spreadsheets/d/${spreadSheetID}/gviz/tq?tqx=out:csv&sheet=${sheetName}`;
@@ -483,11 +483,10 @@
                 /* For each feature in the GeoJSON object above: */
                 for (const meeting in groupedMeetings) {
                     const marker = groupedMeetings[meeting]
-
+                    /* Add a group of meetings marker to map*/
                     if (marker.length > 1) {
                         addGroupMarker(marker)
                     } else {
-                        console.log(marker)
                     /* Create a div element for the marker. */
                     const el = document.createElement('div');
                     /* Assign a unique `id` to the marker. */
@@ -511,7 +510,7 @@
                      **/
                     el.addEventListener('click', (e) => {
                         /* Fly to the point */
-                        flytoMeeting(marker[0].geometry.coordinates, 15);
+                        flytoMeeting(marker[0].geometry.coordinates, 14);
                         /* Close all other popups and display popup for clicked meeting */
                         createPopUp(marker[0]);
                         /* Highlight listing in sidebar */
@@ -528,7 +527,7 @@
                 }
             }
             }
-// TODO: add event listener for meetings in popup list
+
             function addGroupMarker(arrOfMeetings) {
                 const locationKey = (arrOfMeetings[0].geometry.coordinates).toString()
                 const el = document.createElement('div');
@@ -541,6 +540,7 @@
 
                 
                 el.addEventListener('click', e => {
+                    flytoMeeting(arrOfMeetings[0].geometry.coordinates, 14)
                     createGroupPopUp(arrOfMeetings)
                     
                 }, false)
@@ -637,7 +637,7 @@
                     const meetingList = countyList[event.target.id]
                     
                     /* Fly to general are of listings*/
-                    flytoMeeting(meetingList[0].geometry.coordinates, 8)
+                    flytoMeeting(meetingList[0].geometry.coordinates, 10)
                     buildLocationList(meetingList)
                     addMarkers(meetingList)
                 }, false)
@@ -787,9 +787,9 @@
 
             function createGroupPopUp(arrOfMeetings) {
                 const html = `
-                        <ul class='meeting-list'>
-                            ${arrOfMeetings.map((meeting) => `<li class='meeting-item'><a href="#" id=${meeting.properties.Id}>${meeting.properties.Public_body}</a></li>`).join("")}
-                        </ul>
+                        <div class='listings' id='meeting-location'>
+                            ${arrOfMeetings.map((meeting, idx) => `<div class='item'><a href="#" class='meeting-link title' id=${idx}>${meeting.properties.Public_body}</a></div>`).join("")}
+                        </div>
                         `;
                 
                 const popUps = document.getElementsByClassName('mapboxgl-popup');
@@ -801,6 +801,17 @@
                                     ${html}`
                     )
                     .addTo(map);
+
+                const meetingsAtLocation = document.querySelector('#meeting-location')
+
+                meetingsAtLocation.addEventListener('click', e => {
+                    if(!e.target.matches('.meeting-link')) return
+                    e.preventDefault()
+                    popUps[0].remove()
+                    flytoMeeting(arrOfMeetings[e.target.id].geometry.coordinates, 14)
+                    createPopUp(arrOfMeetings[e.target.id])
+
+                })
             }
 
             //adding zoom and rotation controls to map

--- a/publicmeetings.html
+++ b/publicmeetings.html
@@ -479,12 +479,19 @@
              * Add a marker to the map for every meeting listing.
              **/
             function addMarkers(meetings) {
+                const groupedMeetings = groupMeetingsByLocation(meetings)
                 /* For each feature in the GeoJSON object above: */
-                for (const marker of meetings) {
+                for (const meeting in groupedMeetings) {
+                    const marker = groupedMeetings[meeting]
+
+                    if (marker.length > 1) {
+                        addGroupMarker(marker)
+                    } else {
+                        console.log(marker)
                     /* Create a div element for the marker. */
                     const el = document.createElement('div');
                     /* Assign a unique `id` to the marker. */
-                    el.id = `marker-${marker.properties.Id}`;
+                    el.id = `marker-${marker[0].properties.Id}`;
                     /* Assign the `marker` class to each marker for styling. */
                     el.className = 'marker';
 
@@ -493,7 +500,7 @@
                      * defined above and add it to the map.
                      **/
                     new mapboxgl.Marker(el, { offset: [0, -23] })
-                        .setLngLat(marker.geometry.coordinates)
+                        .setLngLat(marker[0].geometry.coordinates)
                         .addTo(map);
 
                     /**
@@ -504,9 +511,9 @@
                      **/
                     el.addEventListener('click', (e) => {
                         /* Fly to the point */
-                        flytoMeeting(marker.geometry.coordinates, 15);
+                        flytoMeeting(marker[0].geometry.coordinates, 15);
                         /* Close all other popups and display popup for clicked meeting */
-                        createPopUp(marker);
+                        createPopUp(marker[0]);
                         /* Highlight listing in sidebar */
                         const activeItem = document.getElementsByClassName('active');
                         e.stopPropagation();
@@ -514,11 +521,48 @@
                             activeItem[0].classList.remove('active');
                         }
                         const listing = document.getElementById(
-                            `listing-${marker.properties.Id}`
+                            `listing-${marker[0].properties.Id}`
                         );
                         listing.classList.add('active');
                     });
                 }
+            }
+            }
+// TODO: add event listener for meetings in popup list
+            function addGroupMarker(arrOfMeetings) {
+                const locationKey = (arrOfMeetings[0].geometry.coordinates).toString()
+                const el = document.createElement('div');
+                el.id = `marker-${locationKey}`
+                el.className = 'marker'
+
+                new mapboxgl.Marker(el, { offset: [0, -23] })
+                    .setLngLat(arrOfMeetings[0].geometry.coordinates)
+                    .addTo(map);
+
+                
+                el.addEventListener('click', e => {
+                    createGroupPopUp(arrOfMeetings)
+                    
+                }, false)
+                
+            }
+
+            function groupMeetingsByLocation(meetings) {
+                const meetingList = {}
+
+                for(let i = 0; i < meetings.length; i++) {
+                    // construct key using lat and long to group by
+                    const coords = meetings[i].geometry.coordinates
+                    const coordsKey = coords.toString()
+
+                    if (meetingList[coordsKey]) {
+                        meetingList[coordsKey].push(meetings[i])
+                    } else {
+                        meetingList[coordsKey] = new Array(meetings[i]) 
+                    }
+                }
+                console.log('grouped obj: ', meetingList)
+                return meetingList
             }
 
             /**
@@ -737,6 +781,24 @@
                                     <td><center>${currentFeature.properties.End_time}</center></td>
                                     <td><center>${currentFeature.properties.Remote_options}</center></td>
                                     </h4>`
+                    )
+                    .addTo(map);
+            }
+
+            function createGroupPopUp(arrOfMeetings) {
+                const html = `
+                        <ul class='meeting-list'>
+                            ${arrOfMeetings.map((meeting) => `<li class='meeting-item'><a href="#" id=${meeting.properties.Id}>${meeting.properties.Public_body}</a></li>`).join("")}
+                        </ul>
+                        `;
+                
+                const popUps = document.getElementsByClassName('mapboxgl-popup');
+                if (popUps[0]) popUps[0].remove();
+                const popup = new mapboxgl.Popup({ closeOnClick: false })
+                    .setLngLat(arrOfMeetings[0].geometry.coordinates)
+                    .setHTML(
+                        `<h3><center>Meetings at this location</center></h3>
+                                    ${html}`
                     )
                     .addTo(map);
             }

--- a/publicmeetings.html
+++ b/publicmeetings.html
@@ -7,6 +7,7 @@
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.8.1/mapbox-gl.css" rel="stylesheet">
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.8.1/mapbox-gl.js"></script>
     <script src="https://npmcdn.com/csv2geojson@latest/csv2geojson.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
     <body>
         <div class="sidebar">
             <div class="heading">
@@ -193,251 +194,58 @@
                 scrollZoom: false
             });
 
-            const meetings = {
-                'type': 'FeatureCollection',
-                'features': [
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates': [-82.547049, 35.595747]
-                        },
-                        'properties': {
-                            'government': 'Buncombe County',
-                            'publicbody': 'Affordable Housing Committee',
-                            'location': 'Buncombe County Permits & Inspections',
-                            'address': '30 Valley Street, Meeting Room, Asheville, NC 28801',
-                            'schedule': '1st Tuesday of every month',
-                            'start': '1:00 PM',
-                            'end': '2:30 PM',
-                            'remote':'',
-                            'id':'1'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates': [-82.55529, 35.59748]
-                        },
-                        'properties': {
-                            'government': 'City of Asheville',
-                            'publicbody': 'Asheville City Council',
-                            'location': 'Harrah’s Cherokee Center',
-                            'address': '87 Haywood St, Asheville, NC 28801',
-                            'schedule': 'Second and fourth Tuesday of every monthh',
-                            'start': '5:00 PM',
-                            'end': '',
-                            'remote':'',
-                            'id': '2'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates': [-82.54826026293046, 35.598922154690385]
-                        },
-                        'properties': {
-                            'government': 'Asheville-Buncombe County',
-                            'publicbody': 'AB Tech/Buncombe County Joint Capital Advisory Committee',
-                            'location': 'County Administration Building',
-                            'address': '200 College Street, Asheville, NC 28801',
-                            'schedule': 'As needed',
-                            'start': '',
-                            'end': '',
-                            'remote':'Zoom',
-                            'id':'3'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates': [-82.548260262931, 35.59892215469039]
-                        },
-                        'properties': {
-                            'government': 'Buncombe County',
-                            'publicbody': 'Ad Hoc Reappraisal Committee',
-                            'location': 'County Administration Building',
-                            'address': '200 College Street, Asheville, NC 28801',
-                            'schedule': '1st and 3rd Wednesday of every month',
-                            'start': '5:00 PM',
-                            'end': '7:00 PM',
-                            'remote':'Watch live through the Engagement Hub: Public Engagement Hub or watch live on the City YouTube Channel.\nListen live by calling 855-925-2801 Enter Code 9409.\nPre-recorded voicemail comments by calling 855-925-2801 Enter Code 9409.  Voicemail comments will be accepted until Wednesday, April 13 at 5:00 p.m.\nWritten public comments by email – AAHCAVL@PublicInput.com.',
-                            'id':'4'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates': [-82.6231, 35.601185]
-                        },
-                        'properties': {
-                            'government': 'Buncombe County',
-                            'publicbody': 'Adult Care Home Community Advisory Committee',
-                            'location': 'Land of Sky Regional Council Offices',
-                            'address': '339 New Leicester Highway, Asheville, NC 28806',
-                            'schedule': '3rd Friday of each month',
-                            'start': '9:00 AM',
-                            'end': '',
-                            'remote':'',
-                            'id':'5'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates': [-82.54873467670735, 35.596417199178475]
-                        },
-                        'properties': {
-                            'government': 'Asheville-Buncombe County',
-                            'publicbody': 'African American Heritage Commission',
-                            'location': 'City Hall',
-                            'address': '70 Court Plaza, 1st Floor North Conference Room Asheville, NC 28801 ',
-                            'schedule': '2nd Thursday of each month',
-                            'start': '11:30 AM',
-                            'end': '',
-                            'remote':'Watch live through the Engagement Hub: Public Engagement Hub or watch live on the City YouTube Channel.\nListen live by calling 855-925-2801 Enter Code 9409.\nPre-recorded voicemail comments by calling 855-925-2801 Enter Code 9409.  Voicemail comments will be accepted until Wednesday, April 13 at 5:00 p.m.\nWritten public comments by email – AAHCAVL@PublicInput.com.',
-                            'id':'6'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates': [-82.6328, 35.61869]
-                        },
-                        'properties': {
-                            'government': 'Buncombe County',
-                            'publicbody': 'Agricultural Advisory Board for Farmland Preservation',
-                            'location': 'Soil & Water Conference',
-                            'address': '49 Mt. Carmel Road, Asheville, NC 28806',
-                            'schedule': '3rd Tuesday of each month',
-                            'start': '11:00 AM',
-                            'end': '12:00 PM ',
-                            'remote':'Zoom',
-                            'id':'7'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates':[-82.54873467670735, 35.596417199178475]
-                        },
-                        'properties': {
-                            'government': 'City of Ashevile',
-                            'publicbody': 'Asheville Board of Adjustment',
-                            'location': 'City Hall',
-                            'address': '70 Court Plaza, 1st Floor North Conference Room Asheville, NC 28801',
-                            'schedule': '4th Monday of each month',
-                            'start': '2:00 PM',
-                            'end': '',
-                            'remote':'Zoom',
-                            'id':'8'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates':[-82.56039420232847, 35.597385858594926]
-                        },
-                        'properties': {
-                            'government': 'Asheville-Buncombe County',
-                            'publicbody': 'Asheville-Buncombe Regional Sports Commission',
-                            'location': 'Chamber of Commerce',
-                            'address': '36 Montford Ave, Asheville, NC 28801',
-                            'schedule': '4th Monday of each month',
-                            'start': '',
-                            'end': '',
-                            'remote':'',
-                            'id':'9'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates':[-79.4014219293032, 36.06924312939426]
-                        },
-                        'properties': {
-                            'government': 'Alamance County',
-                            'publicbody': 'County Commissioners',
-                            'location': 'County Office Building',
-                            'address': '124 W. Elm St., Commissioners Meeting Room located on the 2nd Floor, Graham, NC  27253',
-                            'schedule': '1st Monday and 3rd Monday of the month',
-                            'start': '9:00 AM and 7:00 PM, respectively',
-                            'end': '',
-                            'remote':'Video recordings of our Commissioners Meetings both online and on the local Time-Warner Public Access Channels.  The television broadcast of the meetings will occur on the 2nd and 4th Wednesdays of each month at 10 PM.  Online videos will be made available after processing the videos through Youtube, our service providers for multimedia.  The meetings are now streamed live.',
-                            'id':'10'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates':[-79.451182400000019,36.08054825636156]
-                        },
-                        'properties': {
-                            'government': 'Alamance County',
-                            'publicbody': 'Adult Care Home Community Advisory Committee',
-                            'location': 'J. R. Kernodle Senior Center',
-                            'address': '1535 S Mebane St, Burlington NC 27215',
-                            'schedule': '3rd Tuesday of each quarter',
-                            'start': '2:00 PM',
-                            'end': '',
-                            'remote':'Unknown',
-                            'id':'11'
-                        }
-                    },
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'Point',
-                            'coordinates':[-79.4014219293032, 36.06924312939426]
-                        },
-                        'properties': {
-                            'government': 'My New Meeting County',
-                            'publicbody': 'My New Meeting',
-                            'location': 'Place',
-                            'address': '124 W. Elm St., Commissioners Meeting Room located on the 2nd Floor, Graham, NC  27253',
-                            'schedule': '1st Monday and 3rd Monday of the month',
-                            'start': '9:00 AM and 7:00 PM, respectively',
-                            'end': '',
-                            'remote':'Video recordings of our Commissioners Meetings both online and on the local Time-Warner Public Access Channels.  The television broadcast of the meetings will occur on the 2nd and 4th Wednesdays of each month at 10 PM.  Online videos will be made available after processing the videos through Youtube, our service providers for multimedia.  The meetings are now streamed live.',
-                            'id':'12'
-                        }
-                    },
-                ]
-            };
-            const getMeetingData = () => {
-                fetch(sheetURI)
-                .then(response => response.text())
-                .then(csvMeetings => {
-                    csv2geojson.csv2geojson(csvMeetings, {
+
+            const getMeetingGSheetData = async () => {
+                let meetingGS;
+                try {
+                    const res = await fetch(sheetURI)
+                    const data = await res.text()
+
+
+                    csv2geojson.csv2geojson(data, {
                         latfield: 'Latitude',
                         lonfield: 'Longitude',
                         delimiter: ',',
-                    }, (err, moreMeetings) => {
-                        console.log(moreMeetings)
-                        if (err) {
-                            console.error(err)
-                        }
-                        map.addSource('morePlaces', {
-                            'type': 'geojson',
-                            'data': moreMeetings
-                        })
-                        buildCountyList(moreMeetings)
-                    });
-                }).catch(function (err) {
-                    console.log('Failed to load more meetings', err);
-                });
-
+                    }, (err, data) => {
+                        if (err) throw err
+                        meetingGS = data
+                    })
+                    console.log(meetingGS)
+                    return meetingGS
+                } catch (error) {
+                    throw error
+                }
             }
+
+            const getMeetingJsonData = async () => {
+                try {
+                    const res = await fetch('/meetings.json')
+                    const data = await res.json()
+
+                    return data
+                } catch (error) {
+                    throw error
+                }
+            }
+
+            const mergeMeetingData = async () => {
+
+                let geoJson = {
+                    type: 'FeatureCollection',
+                    features: []
+                }
+                try {
+                    const meetingsGS = await getMeetingGSheetData();
+                    const meetingsJson = await getMeetingJsonData();
+
+                    meetingsGS.features.forEach(f => geoJson.features.push(f))
+                    meetingsJson.features.forEach(j => geoJson.features.push(j))
+                    return geoJson
+                } catch (error) {
+                    throw error
+                }
+            }
+ 
 
             /**
              * Wait until the map loads to make changes to the map.
@@ -447,32 +255,19 @@
                  * This is where your '.addLayer()' used to be, instead
                  * add only the source without styling a layer
                  */
-                // map.addSource('places', {
-                //     'type': 'geojson',
-                //     'data': meetings
-                // });
 
-                /**
-                 * Add all the things to the page:
-                 * - The location listings on the side of the page
-                 * - The markers onto the map
-                 */
-                // buildLocationList(meetings);
-                // addMarkers(meetings);
+                mergeMeetingData()
+                .then(meetings => {
+                    map.addSource('meetingPlaces', {
+                        'type': 'geojson',
+                        'data': meetings
+                    });
 
-                // fetch("meetings.json")
-                // .then(response => response.json())
-                // .then(moreMeetings => {
-                //     map.addSource('morePlaces', {
-                //         'type': 'geojson',
-                //         'data': moreMeetings
-                //     });
+                    buildCountyList(meetings)
+                }).catch(function (err) {
+                    console.log('Failed to meetings', err);
+                });
 
-                //     buildCountyList(moreMeetings)
-                // }).catch(function (err) {
-                //     console.log('Failed to load more meetings', err);
-                // });
-                getMeetingData();
             });
 
             /**

--- a/publicmeetings.html
+++ b/publicmeetings.html
@@ -210,7 +210,7 @@
                         if (err) throw err
                         meetingGS = data
                     })
-                    console.log(meetingGS)
+                    
                     return meetingGS
                 } catch (error) {
                     throw error
@@ -238,8 +238,30 @@
                     const meetingsGS = await getMeetingGSheetData();
                     const meetingsJson = await getMeetingJsonData();
 
-                    meetingsGS.features.forEach(f => geoJson.features.push(f))
                     meetingsJson.features.forEach(j => geoJson.features.push(j))
+                    meetingsGS.features.forEach(f => geoJson.features.push({
+                        geometry: {
+                            type: f.geometry.type,
+                            longitude: f.geometry.coordinates?.[0],
+                            latitude: f.geometry.coordinates?.[1],
+                            coordinates: [...f.geometry?.coordinates],
+                            
+                        },
+                        properties: {
+                            address: f.properties?.Address,
+                            end: f.properties?.End_time,
+                            government: f.properties?.Government,
+                            id: f.properties?.Id,
+                            location: f.properties?.Location,
+                            publicbody: f.properties?.Public_body,
+                            schedule: f.properties?.Schedule,
+                            moreInfo: f.properties?.Source,
+                            start: f.properties?.Start_time,
+                            remote: f.properties?.Remote_options,
+                        },
+                        type: f.type
+                    }))
+
                     return geoJson
                 } catch (error) {
                     throw error
@@ -315,7 +337,7 @@
                             activeItem[0].classList.remove('active');
                         }
                         const listing = document.getElementById(
-                            `listing-${marker[0].properties.Id}`
+                            `listing-${marker[0].properties.id}`
                         );
                         listing.classList.add('active');
                     });
@@ -356,7 +378,6 @@
                         meetingList[coordsKey] = new Array(meetings[i]) 
                     }
                 }
-                console.log('grouped obj: ', meetingList)
                 return meetingList
             }
 
@@ -379,7 +400,7 @@
             **/
             function buildMeetingListByCounty(meetingList) {
                 return meetingList.features.reduce((obj, item) => {
-                    const county = item.properties.Government;
+                    const county = item.properties.Government || item.properties.government;
 
                     if (county !== "") {
                         if (!obj[county]) {
@@ -478,11 +499,15 @@
 
                 /* Continue to add meeting listings */
                 for (const meeting of (meetings)) {
+                    const publicBody = meeting.properties.Public_body || meeting.properties.publicbody
+                    const id = meeting.properties.Id || meeting.properties.id
+                    const location = meeting.properties.Location || meeting.properties.location
+
                     /* Add a new listing section to the sidebar. */
                     const listings = document.getElementById('listings');
                     const listing = listings.appendChild(document.createElement('div'));
                     /* Assign a unique `id` to the listing. */
-                    listing.id = `listing-${meeting.properties.Id}`;
+                    listing.id = `listing-${id}`;
                     /* Assign the `item` class to each listing for styling. */
                     listing.className = 'item';
 
@@ -490,12 +515,12 @@
                     const link = listing.appendChild(document.createElement('a'));
                     link.href = '#';
                     link.className = 'title';
-                    link.id = `link-${meeting.properties.Id}`;
-                    link.innerHTML = `${meeting.properties.Public_body}`;
+                    link.id = `link-${id}`;
+                    link.innerHTML = `${publicBody}`;
 
                     /* Add details to the individual listing. */
                     const details = listing.appendChild(document.createElement('div'));
-                    details.innerHTML = `${meeting.properties.Location}`;
+                    details.innerHTML = `${location}`;
                     if (meeting.properties.phone) {
                         details.innerHTML += ` &middot; ${meeting.properties.phoneFormatted}`;
                     }
@@ -507,9 +532,12 @@
                      * 3. Close all other popups and display popup for clicked meeting
                      * 4. Highlight listing in sidebar (and remove highlight for all other listings)
                      **/
+                    // TODO: use event delgation to create event listeners
                     link.addEventListener('click', function () {
+                        
                         for (const feature of meetings) {
-                            if (this.id === `link-${feature.properties.Id}`) {
+                            const featId = feature.properties.Id || feature.properties.id
+                            if (this.id === `link-${featId}`) {
                                 flytoMeeting(feature.geometry.coordinates, 15);
                                 createPopUp(feature);
                             }
@@ -545,7 +573,7 @@
                 const popup = new mapboxgl.Popup({ closeOnClick: false })
                     .setLngLat(currentFeature.geometry.coordinates)
                     .setHTML(
-                        `<h3><center>${currentFeature.properties.Public_body}</center></h3>
+                        `<h3><center>${currentFeature.properties.publicbody}</center></h3>
                                     <h4>
                                     <table>
                                     <tr>
@@ -554,9 +582,9 @@
                                     <th><center>Location</center></th>
                                     </tr>
                                     <tr>
-                                    <td><center>${currentFeature.properties.Government}</center></td>
-                                    <td><center>${currentFeature.properties.Public_body}</center></td>
-                                    <td><center>${currentFeature.properties.Location}</center></td>
+                                    <td><center>${currentFeature.properties.government}</center></td>
+                                    <td><center>${currentFeature.properties.publicbody}</center></td>
+                                    <td><center>${currentFeature.properties.location}</center></td>
                                     </tr>
                                     <tr>
                                     <th><center>Address</center></th>
@@ -564,17 +592,17 @@
                                     <th><center>Start Time</center></th>
                                     </tr>
                                     <tr>
-                                    <td><center>${currentFeature.properties.Address}</center></td>
-                                    <td><center>${currentFeature.properties.Schedule}</center></td>
-                                    <td><center>${currentFeature.properties.Start_time}</center></td>
+                                    <td><center>${currentFeature.properties.address}</center></td>
+                                    <td><center>${currentFeature.properties.schedule}</center></td>
+                                    <td><center>${currentFeature.properties.start}</center></td>
                                     </tr>
                                     <tr>
                                     <th><center>End Time</center></th>
                                     <th><center>Remote Options</center></th>
                                     </tr>
                                     <tr>
-                                    <td><center>${currentFeature.properties.End_time}</center></td>
-                                    <td><center>${currentFeature.properties.Remote_options}</center></td>
+                                    <td><center>${currentFeature.properties.end}</center></td>
+                                    <td><center>${currentFeature.properties.remote}</center></td>
                                     </h4>`
                     )
                     .addTo(map);
@@ -583,7 +611,7 @@
             function createGroupPopUp(arrOfMeetings) {
                 const html = `
                         <div class='listings' id='meeting-location'>
-                            ${arrOfMeetings.map((meeting, idx) => `<div class='item'><a href="#" class='meeting-link title' id=${idx}>${meeting.properties.Public_body}</a></div>`).join("")}
+                            ${arrOfMeetings.map((meeting, idx) => `<div class='item'><a href="#" class='meeting-link title' id=${idx}>${meeting.properties.publicbody}</a></div>`).join("")}
                         </div>
                         `;
                 

--- a/publicmeetings.html
+++ b/publicmeetings.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no">
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.8.1/mapbox-gl.css" rel="stylesheet">
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.8.1/mapbox-gl.js"></script>
+    <script src="https://npmcdn.com/csv2geojson@latest/csv2geojson.js"></script>
     <body>
         <div class="sidebar">
             <div class="heading">
@@ -178,6 +179,9 @@
             mapboxgl.accessToken = 'pk.eyJ1IjoiY2N0aGVncmVhdCIsImEiOiJjbDI2a2lodnYwMnRnM2ZvdXVhZXNjbHd0In0.4CfhKr_VP1IDEM08Nk7PXg';
             const stateCoords = [-79.8, 35.3] 
             const defaultZoom = 6
+            const spreadSheetID = '12GiMtxkEZA-TzAB0iBf3S_euXBId7HaPlWUvpOf9p-Q';
+            const sheetName = 'all';
+            const sheetURI = `https://docs.google.com/spreadsheets/d/${spreadSheetID}/gviz/tq?tqx=out:csv&sheet=${sheetName}`;
             /**
              * Add the map to the page
              */
@@ -410,6 +414,30 @@
                     },
                 ]
             };
+            const getMeetingData = () => {
+                fetch(sheetURI)
+                .then(response => response.text())
+                .then(csvMeetings => {
+                    csv2geojson.csv2geojson(csvMeetings, {
+                        latfield: 'Latitude',
+                        lonfield: 'Longitude',
+                        delimiter: ',',
+                    }, (err, moreMeetings) => {
+                        console.log(moreMeetings)
+                        if (err) {
+                            console.error(err)
+                        }
+                        map.addSource('morePlaces', {
+                            'type': 'geojson',
+                            'data': moreMeetings
+                        })
+                        buildCountyList(moreMeetings)
+                    });
+                }).catch(function (err) {
+                    console.log('Failed to load more meetings', err);
+                });
+
+            }
 
             /**
              * Wait until the map loads to make changes to the map.
@@ -432,18 +460,19 @@
                 // buildLocationList(meetings);
                 // addMarkers(meetings);
 
-                fetch("meetings.json")
-                .then(response => response.json())
-                .then(moreMeetings => {
-                    map.addSource('morePlaces', {
-                        'type': 'geojson',
-                        'data': moreMeetings
-                    });
+                // fetch("meetings.json")
+                // .then(response => response.json())
+                // .then(moreMeetings => {
+                //     map.addSource('morePlaces', {
+                //         'type': 'geojson',
+                //         'data': moreMeetings
+                //     });
 
-                    buildCountyList(moreMeetings)
-                }).catch(function (err) {
-                    console.log('Failed to load more meetings', err);
-                });
+                //     buildCountyList(moreMeetings)
+                // }).catch(function (err) {
+                //     console.log('Failed to load more meetings', err);
+                // });
+                getMeetingData();
             });
 
             /**
@@ -455,7 +484,7 @@
                     /* Create a div element for the marker. */
                     const el = document.createElement('div');
                     /* Assign a unique `id` to the marker. */
-                    el.id = `marker-${marker.properties.id}`;
+                    el.id = `marker-${marker.properties.Id}`;
                     /* Assign the `marker` class to each marker for styling. */
                     el.className = 'marker';
 
@@ -485,7 +514,7 @@
                             activeItem[0].classList.remove('active');
                         }
                         const listing = document.getElementById(
-                            `listing-${marker.properties.id}`
+                            `listing-${marker.properties.Id}`
                         );
                         listing.classList.add('active');
                     });
@@ -511,7 +540,7 @@
             **/
             function buildMeetingListByCounty(meetingList) {
                 return meetingList.features.reduce((obj, item) => {
-                    const county = item.properties.government;
+                    const county = item.properties.Government;
 
                     if (county !== "") {
                         if (!obj[county]) {
@@ -614,7 +643,7 @@
                     const listings = document.getElementById('listings');
                     const listing = listings.appendChild(document.createElement('div'));
                     /* Assign a unique `id` to the listing. */
-                    listing.id = `listing-${meeting.properties.id}`;
+                    listing.id = `listing-${meeting.properties.Id}`;
                     /* Assign the `item` class to each listing for styling. */
                     listing.className = 'item';
 
@@ -622,12 +651,12 @@
                     const link = listing.appendChild(document.createElement('a'));
                     link.href = '#';
                     link.className = 'title';
-                    link.id = `link-${meeting.properties.id}`;
-                    link.innerHTML = `${meeting.properties.publicbody}`;
+                    link.id = `link-${meeting.properties.Id}`;
+                    link.innerHTML = `${meeting.properties.Public_body}`;
 
                     /* Add details to the individual listing. */
                     const details = listing.appendChild(document.createElement('div'));
-                    details.innerHTML = `${meeting.properties.location}`;
+                    details.innerHTML = `${meeting.properties.Location}`;
                     if (meeting.properties.phone) {
                         details.innerHTML += ` &middot; ${meeting.properties.phoneFormatted}`;
                     }
@@ -641,7 +670,7 @@
                      **/
                     link.addEventListener('click', function () {
                         for (const feature of meetings) {
-                            if (this.id === `link-${feature.properties.id}`) {
+                            if (this.id === `link-${feature.properties.Id}`) {
                                 flytoMeeting(feature.geometry.coordinates, 15);
                                 createPopUp(feature);
                             }
@@ -677,7 +706,7 @@
                 const popup = new mapboxgl.Popup({ closeOnClick: false })
                     .setLngLat(currentFeature.geometry.coordinates)
                     .setHTML(
-                        `<h3><center>${currentFeature.properties.publicbody}</center></h3>
+                        `<h3><center>${currentFeature.properties.Public_body}</center></h3>
                                     <h4>
                                     <table>
                                     <tr>
@@ -686,9 +715,9 @@
                                     <th><center>Location</center></th>
                                     </tr>
                                     <tr>
-                                    <td><center>${currentFeature.properties.government}</center></td>
-                                    <td><center>${currentFeature.properties.publicbody}</center></td>
-                                    <td><center>${currentFeature.properties.location}</center></td>
+                                    <td><center>${currentFeature.properties.Government}</center></td>
+                                    <td><center>${currentFeature.properties.Public_body}</center></td>
+                                    <td><center>${currentFeature.properties.Location}</center></td>
                                     </tr>
                                     <tr>
                                     <th><center>Address</center></th>
@@ -696,17 +725,17 @@
                                     <th><center>Start Time</center></th>
                                     </tr>
                                     <tr>
-                                    <td><center>${currentFeature.properties.address}</center></td>
-                                    <td><center>${currentFeature.properties.schedule}</center></td>
-                                    <td><center>${currentFeature.properties.start}</center></td>
+                                    <td><center>${currentFeature.properties.Address}</center></td>
+                                    <td><center>${currentFeature.properties.Schedule}</center></td>
+                                    <td><center>${currentFeature.properties.Start_time}</center></td>
                                     </tr>
                                     <tr>
                                     <th><center>End Time</center></th>
                                     <th><center>Remote Options</center></th>
                                     </tr>
                                     <tr>
-                                    <td><center>${currentFeature.properties.end}</center></td>
-                                    <td><center>${currentFeature.properties.remote}</center></td>
+                                    <td><center>${currentFeature.properties.End_time}</center></td>
+                                    <td><center>${currentFeature.properties.Remote_options}</center></td>
                                     </h4>`
                     )
                     .addTo(map);


### PR DESCRIPTION
Created another pin popup view for multiple meetings at the same  geo-coordinates.

Created process to pull meeting entries from a csv file on google docs. Currently pulling from doc that was created by Rick. 

(if duplicate meetings exist across meetings.json and this spreadsheet, both will show)